### PR TITLE
fix issue #19 - change direct links to use Url Helper

### DIFF
--- a/assets/photos/photos.js
+++ b/assets/photos/photos.js
@@ -72,12 +72,13 @@ $(function(){
     photosBody.on('input propertychange', '.photo-description', function(){
         var saveBtn = $(this).siblings('.save-photo-description');
         if(saveBtn.hasClass('disabled')){
-            saveBtn.removeClass('disabled').on('click', function(){
+            saveBtn.removeClass('disabled').on('click', function(e){
+                e.preventDefault();
                 var $this = $(this).unbind('click').addClass('disabled');
                 var tr = $this.closest('tr');
                 var text = $this.siblings('.photo-description').val();
                 $.post(
-                    '/admin/photos/description/'+ tr.data('id'),
+                    $this.attr('href'),
                     {description: text},
                     function(response){
                         if(response.result === 'success'){

--- a/components/API.php
+++ b/components/API.php
@@ -27,7 +27,7 @@ class API extends \yii\base\Object
 
     public function wrapLiveEdit($text, $path, $tag = 'span')
     {
-        return '<'.$tag.' class="easyiicms-edit" data-edit="/admin/'.$this->module.'/'.$path.'">'.$text.'</'.$tag.'>';
+        return '<'.$tag.' class="easyiicms-edit" data-edit="'. Yii::$app->urlManager->createAbsoluteUrl(["/admin/$this->module/$path"]) . '">'.$text.'</'.$tag.'>';
     }
 
     public function  errorText($text)

--- a/components/Controller.php
+++ b/components/Controller.php
@@ -18,7 +18,7 @@ class Controller extends \yii\web\Controller
 
         if(Yii::$app->user->isGuest){
             Yii::$app->user->setReturnUrl(Yii::$app->request->url);
-            return $this->redirect('/admin/sign/in');
+            return $this->redirect(['/admin/sign/in']);
         }
         else{
 

--- a/controllers/AdminsController.php
+++ b/controllers/AdminsController.php
@@ -15,7 +15,7 @@ class AdminsController extends \yii\easyii\components\Controller
         $data = new ActiveDataProvider([
             'query' => Admin::find()->desc(),
         ]);
-        Yii::$app->user->setReturnUrl('/admin/admins');
+        Yii::$app->user->setReturnUrl(['/admin/admins']);
 
         return $this->render('index', [
             'data' => $data
@@ -35,7 +35,7 @@ class AdminsController extends \yii\easyii\components\Controller
             else{
                 if($model->save()){
                     $this->flash('success', Yii::t('easyii', 'Admin created'));
-                    return $this->redirect('/admin/admins');
+                    return $this->redirect(['/admin/admins']);
                 }
                 else{
                     $this->flash('error', Yii::t('easyii', 'Create error. {0}', $model->formatErrors()));
@@ -56,7 +56,7 @@ class AdminsController extends \yii\easyii\components\Controller
 
         if($model === null){
             $this->flash('error', Yii::t('easyii', 'Not found'));
-            return $this->redirect('/admin/admins');
+            return $this->redirect(['/admin/admins']);
         }
 
         if ($model->load(Yii::$app->request->post())) {

--- a/controllers/InstallController.php
+++ b/controllers/InstallController.php
@@ -47,7 +47,7 @@ class InstallController extends \yii\web\Controller
             Yii::$app->cache->flush();
             Yii::$app->session->setFlash('root_password', $installForm->root_password);
 
-            return $this->redirect('/admin/install/finish');
+            return $this->redirect(['/admin/install/finish']);
         }
         else {
             $installForm->robot_email = 'noreply@'.Yii::$app->request->serverName;
@@ -68,7 +68,7 @@ class InstallController extends \yii\web\Controller
                 'password' => $root_password,
             ]);
             if($loginForm->login()){
-                return $this->redirect('/admin/');
+                return $this->redirect(['/admin/']);
             }
         }
 

--- a/controllers/ModulesController.php
+++ b/controllers/ModulesController.php
@@ -51,7 +51,7 @@ class ModulesController extends \yii\easyii\components\Controller
             else{
                 if($model->save()){
                     $this->flash('success', Yii::t('easyii', 'Module created'));
-                    return $this->redirect('/admin/modules');
+                    return $this->redirect(['/admin/modules']);
                 }
                 else{
                     $this->flash('error', Yii::t('Create error. {0}', $model->formatErrors()));
@@ -72,7 +72,7 @@ class ModulesController extends \yii\easyii\components\Controller
 
         if($model === null){
             $this->flash('error', Yii::t('easyii', 'Not found'));
-            return $this->redirect('/admin/modules');
+            return $this->redirect(['/admin/modules']);
         }
 
         if ($model->load(Yii::$app->request->post())) {
@@ -103,7 +103,7 @@ class ModulesController extends \yii\easyii\components\Controller
 
         if($model === null){
             $this->flash('error', Yii::t('easyii', 'Not found'));
-            return $this->redirect('/admin/modules');
+            return $this->redirect(['/admin/modules']);
         }
 
         if (Yii::$app->request->post('Settings')) {

--- a/controllers/PhotosController.php
+++ b/controllers/PhotosController.php
@@ -2,6 +2,7 @@
 namespace yii\easyii\controllers;
 
 use Yii;
+use yii\helpers\Url;
 use yii\web\UploadedFile;
 use yii\web\Response;
 
@@ -37,7 +38,7 @@ class PhotosController extends Controller
     public function actionUpload($model, $item_id, $maxWidth, $thumbWidth, $thumbHeight = null, $thumbCrop = true)
     {
         $success = null;
-        
+
         $photo = new Photo;
         $photo->model = $model;
         $photo->item_id = $item_id;
@@ -59,8 +60,8 @@ class PhotosController extends Controller
                     ];
                 }
                 else{
-                    @unlink(Yii::getAlias('@webroot').$photo->image);
-                    @unlink(Yii::getAlias('@webroot').$photo->thumb);
+                    @unlink(Yii::getAlias('@webroot') . str_replace(Url::base(true), '', $photo->image));
+                    @unlink(Yii::getAlias('@webroot') . str_replace(Url::base(true), '', $photo->thumb));
                     $this->error = Yii::t('easyii', 'Create error. {0}', $photo->formatErrors());
                 }
             }

--- a/controllers/RedactorController.php
+++ b/controllers/RedactorController.php
@@ -4,6 +4,7 @@ namespace yii\easyii\controllers;
 use Yii;
 use yii\web\HttpException;
 use yii\helpers\FileHelper;
+use yii\helpers\Url;
 use yii\web\UploadedFile;
 use yii\web\Response;
 
@@ -116,7 +117,7 @@ class RedactorController extends \yii\easyii\components\Controller
     private function getResponse($fileName)
     {
         return [
-            'filelink' => 'http://'.Yii::$app->request->serverName.$fileName,
+            'filelink' => Url::base(true) . $filename,
             'filename' => basename($fileName)
         ];
     }

--- a/controllers/RedactorController.php
+++ b/controllers/RedactorController.php
@@ -117,7 +117,7 @@ class RedactorController extends \yii\easyii\components\Controller
     private function getResponse($fileName)
     {
         return [
-            'filelink' => Url::base(true) . $filename,
+            'filelink' => $fileName,
             'filename' => basename($fileName)
         ];
     }

--- a/controllers/SettingsController.php
+++ b/controllers/SettingsController.php
@@ -55,7 +55,7 @@ class SettingsController extends \yii\easyii\components\Controller
 
         if($model === null || ($model->visibility < (IS_ROOT ? Setting::VISIBLE_ROOT : Setting::VISIBLE_ALL))){
             $this->flash('error', Yii::t('easyii', 'Not found'));
-            return $this->redirect('/admin/settings');
+            return $this->redirect(['/admin/settings']);
         }
 
         if ($model->load(Yii::$app->request->post())) {

--- a/controllers/SignController.php
+++ b/controllers/SignController.php
@@ -14,7 +14,7 @@ class SignController extends \yii\web\Controller
         $model = new models\LoginForm;
 
         if (!Yii::$app->user->isGuest || ($model->load(Yii::$app->request->post()) && $model->login())) {
-            return $this->redirect(Yii::$app->user->getReturnUrl('/admin'));
+            return $this->redirect(Yii::$app->user->getReturnUrl(['/admin']));
         } else {
             return $this->render('in', [
                 'model' => $model,

--- a/helpers/Image.php
+++ b/helpers/Image.php
@@ -5,6 +5,7 @@ use Yii;
 use yii\web\UploadedFile;
 use yii\web\HttpException;
 use yii\helpers\FileHelper;
+use yii\helpers\Url;
 use yii\easyii\helpers\GD;
 
 class Image
@@ -26,6 +27,8 @@ class Image
 
     static function createThumbnail($fileName, $width, $height = null, $crop = true)
     {
+        $fileName = str_replace(Url::base(true), '', $fileName);
+        
         $webRoot = Yii::getAlias('@webroot');
         if(!strstr($fileName, $webRoot)){
             $fileName = $webRoot . $fileName;

--- a/helpers/Upload.php
+++ b/helpers/Upload.php
@@ -7,6 +7,7 @@ use \yii\web\HttpException;
 use yii\helpers\Inflector;
 use yii\helpers\StringHelper;
 use yii\helpers\FileHelper;
+use yii\helpers\Url;
 
 class Upload
 {
@@ -33,7 +34,7 @@ class Upload
 
     static function getLink($fileName)
     {
-        return str_replace('\\', '/', str_replace(Yii::getAlias('@webroot'), '', $fileName));
+        return Url::base(true) . str_replace('\\', '/', str_replace(Yii::getAlias('@webroot'), '', $fileName));
     }
 
     static function getFileName($fileInstanse, $namePostfix = true)

--- a/media/js/admin.js
+++ b/media/js/admin.js
@@ -51,7 +51,7 @@ $(function(){
         var checkbox = $(this);
         checkbox.switcher('setDisabled', true);
 
-        $.getJSON(checkbox.data('link') + (checkbox.is(':checked') ? 'on' : 'off') + '/' + checkbox.data('id'), function(response){
+        $.getJSON(checkbox.data('link') + '/' + (checkbox.is(':checked') ? 'on' : 'off') + '/' + checkbox.data('id'), function(response){
             if(response.result === 'error'){
                 alert(response.error);
             }

--- a/media/js/frontend.js
+++ b/media/js/frontend.js
@@ -6,6 +6,6 @@ $(function(){
     $('#easyii-navbar input').switcher({copy: {en: {yes: '', no: ''}}}).on('change', function(){
         var checkbox = $(this);
         checkbox.switcher('setDisabled', true);
-        location.href = '/admin/system/live-edit/'+(checkbox.is(':checked') ? 1 : 0);
+        location.href = checkbox.attr('data-link') + '/' + (checkbox.is(':checked') ? 1 : 0);
     });;
 });

--- a/modules/article/api/Article.php
+++ b/modules/article/api/Article.php
@@ -3,6 +3,7 @@ namespace yii\easyii\modules\article\api;
 
 use Yii;
 use yii\data\ActiveDataProvider;
+use yii\helpers\Url;
 use yii\widgets\LinkPager;
 
 use yii\easyii\widgets\Colorbox;
@@ -207,7 +208,7 @@ class Article extends \yii\easyii\components\API
             return $this->createCatObject('');
         }
         elseif(preg_match(Category::$slugPattern, $id_slug)){
-            return $this->createCatObject('<a href="/admin/article/a/create/?slug='.$id_slug.'" target="_blank">'.Yii::t('easyii/article/api', 'Create category').'</a>');
+            return $this->createCatObject('<a href="' . Url::to(['/admin/article/a/create', 'slug' => $id_slug] . '" target="_blank">'.Yii::t('easyii/article/api', 'Create category').'</a>');
         }
         else{
             return $this->createCatObject($this->errorText('WRONG CATEGORY IDENTIFIER'));

--- a/modules/article/controllers/AController.php
+++ b/modules/article/controllers/AController.php
@@ -62,7 +62,7 @@ class AController extends Controller
 
                 if($model->save()){
                     $this->flash('success', Yii::t('easyii/article', 'Category created'));
-                    return $this->redirect('/admin/article/items/'.$model->primaryKey);
+                    return $this->redirect(['/admin/article/items/index', 'id' => $model->primaryKey]);
                 }
                 else{
                     $this->flash('error', Yii::t('easyii', 'Create error. {0}', $model->formatErrors()));
@@ -82,7 +82,7 @@ class AController extends Controller
     public function actionEdit($id)
     {
         if(!($model = Category::findOne($id))){
-            return $this->redirect('/admin/article');
+            return $this->redirect(['/admin/article/']);
         }
 
         if ($model->load(Yii::$app->request->post())) {

--- a/modules/article/controllers/ItemsController.php
+++ b/modules/article/controllers/ItemsController.php
@@ -26,7 +26,7 @@ class ItemsController extends Controller
     public function actionIndex($id)
     {
         if(!($model = Category::findOne($id))){
-            return $this->redirect('/admin/article');
+            return $this->redirect(['/admin/article']);
         }
 
         return $this->render('index', [
@@ -38,7 +38,7 @@ class ItemsController extends Controller
     public function actionCreate($id)
     {
         if(!($category = Category::findOne($id))){
-            return $this->redirect('/admin/article');
+            return $this->redirect(['/admin/article']);
         }
 
         $model = new Item;
@@ -62,7 +62,7 @@ class ItemsController extends Controller
 
                 if ($model->save()) {
                     $this->flash('success', Yii::t('easyii/article', 'Article created'));
-                    return $this->redirect('/admin/article/items/edit/' . $model->primaryKey);
+                    return $this->redirect(['/admin/article/items/edit', 'id' => $model->primaryKey]);
                 } else {
                     $this->flash('error', Yii::t('easyii', 'Create error. {0}', $model->formatErrors()));
                     return $this->refresh();
@@ -80,7 +80,7 @@ class ItemsController extends Controller
     public function actionEdit($id)
     {
         if(!($model = Item::findOne($id))){
-            return $this->redirect('/admin/article');
+            return $this->redirect(['/admin/article']);
         }
 
         if ($model->load(Yii::$app->request->post())) {
@@ -100,7 +100,7 @@ class ItemsController extends Controller
 
                 if ($model->save()) {
                     $this->flash('success', Yii::t('easyii/article', 'Article updated'));
-                    return $this->redirect('/admin/article/items/edit/' . $model->primaryKey);
+                    return $this->redirect(['/admin/article/items/edit', 'id' => $model->primaryKey]);
                 } else {
                     $this->flash('error', Yii::t('easyii', 'Update error. {0}', $model->formatErrors()));
                     return $this->refresh();

--- a/modules/article/views/a/_form.php
+++ b/modules/article/views/a/_form.php
@@ -13,7 +13,7 @@ $settings = $this->context->module->settings;
 <?= $form->field($model, 'title') ?>
 <?php if($settings['categoryThumb']) : ?>
     <?php if($model->thumb) : ?>
-        <img src="<?= Yii::$app->request->baseUrl.$model->thumb ?>">
+        <img src="<?= $model->thumb ?>">
         <a href="<?= Url::to(['/admin/article/a/clear-image', 'id' => $model->primaryKey]) ?>" class="text-danger confirm-delete" title="<?= Yii::t('easyii/article', 'Clear image')?>"><?= Yii::t('easyii/article', 'Clear image')?></a>
     <?php endif; ?>
     <?= $form->field($model, 'thumb')->fileInput() ?>

--- a/modules/article/views/a/_form.php
+++ b/modules/article/views/a/_form.php
@@ -1,5 +1,6 @@
 <?php
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\widgets\ActiveForm;
 use yii\easyii\widgets\SeoForm;
 
@@ -13,7 +14,7 @@ $settings = $this->context->module->settings;
 <?php if($settings['categoryThumb']) : ?>
     <?php if($model->thumb) : ?>
         <img src="<?= Yii::$app->request->baseUrl.$model->thumb ?>">
-        <a href="/admin/article/a/clear-image/<?= $model->primaryKey ?>" class="text-danger confirm-delete" title="<?= Yii::t('easyii/article', 'Clear image')?>"><?= Yii::t('easyii/article', 'Clear image')?></a>
+        <a href="<?= Url::to(['/admin/article/a/clear-image', 'id' => $model->primaryKey]) ?>" class="text-danger confirm-delete" title="<?= Yii::t('easyii/article', 'Clear image')?>"><?= Yii::t('easyii/article', 'Clear image')?></a>
     <?php endif; ?>
     <?= $form->field($model, 'thumb')->fileInput() ?>
 <?php endif; ?>

--- a/modules/article/views/a/_menu.php
+++ b/modules/article/views/a/_menu.php
@@ -1,15 +1,17 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 <ul class="nav nav-pills">
     <li <?= ($action === 'index') ? 'class="active"' : '' ?>>
-        <a href="<?= $this->context->getReturnUrl('/admin/article') ?>">
+        <a href="<?= $this->context->getReturnUrl(['/admin/article/']) ?>">
             <?php if($action === 'fields' || $action === 'edit') : ?>
                 <i class="glyphicon glyphicon-chevron-left font-12"></i>
             <?php endif; ?>
             <?= Yii::t('easyii/article', 'Categories') ?>
         </a>
     </li>
-    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="/admin/article/a/create"><?= Yii::t('easyii/article', 'Create category') ?></a></li>
+    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/article/a/create']) ?>"><?= Yii::t('easyii/article', 'Create category') ?></a></li>
 </ul>
 <br/>

--- a/modules/article/views/a/index.php
+++ b/modules/article/views/a/index.php
@@ -1,5 +1,6 @@
 <?php
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\easyii\modules\article\models\Category;
 
 $this->title = Yii::t('easyii/article', 'Articles');
@@ -26,21 +27,21 @@ $this->title = Yii::t('easyii/article', 'Articles');
                 <?php if(IS_ROOT) : ?>
                     <td><?= $item->primaryKey ?></td>
                 <?php endif; ?>
-                <td><a href="/admin/article/items/<?= $item->primaryKey ?>"><?= $item->title ?></a></td>
+                <td><a href="<?= Url::to(['/admin/article/items', 'id' => $item->primaryKey]) ?>"><?= $item->title ?></a></td>
                 <td><?= $item->item_count ?></td>
                 <td class="status">
                     <?= Html::checkbox('', $item->status == Category::STATUS_ON, [
                         'class' => 'switch',
                         'data-id' => $item->primaryKey,
-                        'data-link' => '/admin/article/a/'
+                        'data-link' => Url::to(['/admin/article/a/']),
                     ]) ?>
                 </td>
                 <td class="control">
                     <div class="btn-group btn-group-sm" role="group">
-                        <a href="/admin/article/a/up/<?= $item->primaryKey ?>" class="btn btn-default move-up" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
-                        <a href="/admin/article/a/down/<?= $item->primaryKey ?>" class="btn btn-default move-down" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
-                        <a href="/admin/article/a/edit/<?= $item->primaryKey ?>" class="btn btn-default" title="<?= Yii::t('easyii/article', 'Edit category') ?>"><span class="glyphicon glyphicon-pencil"></span></a>
-                        <a href="/admin/article/a/delete/<?= $item->primaryKey ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
+                        <a href="<?= Url::to(['/admin/article/a/up', 'id' => $item->primaryKey]) ?>" class="btn btn-default move-up" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
+                        <a href="<?= Url::to(['/admin/article/a/down', 'id' => $item->primaryKey]) ?>" class="btn btn-default move-down" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
+                        <a href="<?= Url::to(['/admin/article/a/edit', 'id' => $item->primaryKey]) ?>" class="btn btn-default" title="<?= Yii::t('easyii/article', 'Edit category') ?>"><span class="glyphicon glyphicon-pencil"></span></a>
+                        <a href="<?= Url::to(['/admin/article/a/delete', 'id' => $item->primaryKey]) ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
                     </div>
                 </td>
             </tr>

--- a/modules/article/views/a/index.php
+++ b/modules/article/views/a/index.php
@@ -33,7 +33,7 @@ $this->title = Yii::t('easyii/article', 'Articles');
                     <?= Html::checkbox('', $item->status == Category::STATUS_ON, [
                         'class' => 'switch',
                         'data-id' => $item->primaryKey,
-                        'data-link' => Url::to(['/admin/article/a/']),
+                        'data-link' => Url::to(['/admin/article/a/']) . '/',
                     ]) ?>
                 </td>
                 <td class="control">

--- a/modules/article/views/a/index.php
+++ b/modules/article/views/a/index.php
@@ -33,7 +33,7 @@ $this->title = Yii::t('easyii/article', 'Articles');
                     <?= Html::checkbox('', $item->status == Category::STATUS_ON, [
                         'class' => 'switch',
                         'data-id' => $item->primaryKey,
-                        'data-link' => Url::to(['/admin/article/a/']) . '/',
+                        'data-link' => Url::to(['/admin/article/a/']),
                     ]) ?>
                 </td>
                 <td class="control">

--- a/modules/article/views/items/_form.php
+++ b/modules/article/views/items/_form.php
@@ -1,5 +1,6 @@
 <?php
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\widgets\ActiveForm;
 use yii\easyii\widgets\Redactor;
 use yii\easyii\widgets\SeoForm;
@@ -12,7 +13,7 @@ use yii\easyii\widgets\SeoForm;
 <?php if($this->context->module->settings['articleThumb']) : ?>
     <?php if($model->thumb) : ?>
         <img src="<?= Yii::$app->request->baseUrl.$model->thumb ?>">
-        <a href="/admin/article/items/clear-image/<?= $model->primaryKey ?>" class="text-danger confirm-delete" title="<?= Yii::t('easyii/article', 'Clear image')?>"><?= Yii::t('easyii/article', 'Clear image')?></a>
+        <a href="<?= Url::to(['/admin/article/items/clear-image', 'id' => $model->primaryKey]) ?>" class="text-danger confirm-delete" title="<?= Yii::t('easyii/article', 'Clear image')?>"><?= Yii::t('easyii/article', 'Clear image')?></a>
     <?php endif; ?>
     <?= $form->field($model, 'thumb')->fileInput() ?>
 <?php endif; ?>
@@ -22,8 +23,8 @@ use yii\easyii\widgets\SeoForm;
 <?= $form->field($model, 'text')->widget(Redactor::className(),[
     'options' => [
         'minHeight' => 400,
-        'imageUpload' => '/admin/redactor/upload?dir=article',
-        'fileUpload' => '/admin/redactor/upload?dir=article',
+        'imageUpload' => Url::to(['/admin/redactor/upload', 'dir' => 'article'], true),
+        'fileUpload' => Url::to(['/admin/redactor/upload', 'dir' => 'article'], true),
         'plugins' => ['fullscreen']
     ]
 ]) ?>

--- a/modules/article/views/items/_form.php
+++ b/modules/article/views/items/_form.php
@@ -12,7 +12,7 @@ use yii\easyii\widgets\SeoForm;
 <?= $form->field($model, 'title') ?>
 <?php if($this->context->module->settings['articleThumb']) : ?>
     <?php if($model->thumb) : ?>
-        <img src="<?= Yii::$app->request->baseUrl.$model->thumb ?>">
+        <img src="<?= $model->thumb ?>">
         <a href="<?= Url::to(['/admin/article/items/clear-image', 'id' => $model->primaryKey]) ?>" class="text-danger confirm-delete" title="<?= Yii::t('easyii/article', 'Clear image')?>"><?= Yii::t('easyii/article', 'Clear image')?></a>
     <?php endif; ?>
     <?= $form->field($model, 'thumb')->fileInput() ?>

--- a/modules/article/views/items/_menu.php
+++ b/modules/article/views/items/_menu.php
@@ -1,11 +1,13 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 <ul class="nav nav-pills">
     <?php if($action === 'index') : ?>
-        <li><a href="/admin/article"><i class="glyphicon glyphicon-chevron-left font-12"></i> <?= Yii::t('easyii/article', 'Categories') ?></a></li>
+        <li><a href="<?= Url::to(['/admin/article/']) ?>"><i class="glyphicon glyphicon-chevron-left font-12"></i> <?= Yii::t('easyii/article', 'Categories') ?></a></li>
     <?php endif; ?>
-    <li <?= ($action === 'index') ? 'class="active"' : '' ?>><a href="/admin/article/items/<?= $category->primaryKey ?>"><?php if($action !== 'index') echo '<i class="glyphicon glyphicon-chevron-left font-12"></i> ' ?><?= $category->title ?></a></li>
-    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="/admin/article/items/create/<?= $category->primaryKey ?>"><?= Yii::t('easyii', 'Add') ?></a></li>
+    <li <?= ($action === 'index') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/article/items/index', 'id' => $category->primaryKey]) ?>"><?php if($action !== 'index') echo '<i class="glyphicon glyphicon-chevron-left font-12"></i> ' ?><?= $category->title ?></a></li>
+    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/article/items/create', 'id' => $category->primaryKey]) ?>"><?= Yii::t('easyii', 'Add') ?></a></li>
 </ul>
 <br/>

--- a/modules/article/views/items/index.php
+++ b/modules/article/views/items/index.php
@@ -1,4 +1,6 @@
 <?php
+use yii\helpers\Url;
+
 $this->title = Yii::t('easyii/article', 'Articles');
 ?>
 <?= $this->render('_menu', ['category' => $model]) ?>
@@ -21,13 +23,13 @@ $this->title = Yii::t('easyii/article', 'Articles');
                 <?php if(IS_ROOT) : ?>
                     <td><?= $item->primaryKey ?></td>
                 <?php endif; ?>
-                <td><a href="/admin/article/items/edit/<?= $item->primaryKey ?>"><?= $item->title ?></a></td>
+                <td><a href="<?= Url::to(['/admin/article/items/edit', 'id' => $item->primaryKey]) ?>"><?= $item->title ?></a></td>
                 <td><?= $item->views ?></td>
                 <td class="text-right">
                     <div class="btn-group btn-group-sm" role="group">
-                        <a href="/admin/article/items/up/<?= $item->primaryKey ?>?category_id=<?= $model->primaryKey ?>" class="btn btn-default move-up" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
-                        <a href="/admin/article/items/down/<?= $item->primaryKey ?>?category_id=<?= $model->primaryKey ?>" class="btn btn-default move-down" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
-                        <a href="/admin/article/items/delete/<?= $item->primaryKey ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
+                        <a href="<?= Url::to(['/admin/article/items/up', 'id' => $item->primaryKey, 'category_id' => $model->primaryKey]) ?>" class="btn btn-default move-up" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
+                        <a href="<?= Url::to(['/admin/article/items/down', 'id' => $item->primaryKey, 'category_id' => $model->primaryKey]) ?>" class="btn btn-default move-down" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
+                        <a href="<?= Url::to(['/admin/article/items/delete', 'id' => $item->primaryKey]) ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
                     </div>
                 </td>
             </tr>

--- a/modules/carousel/api/Carousel.php
+++ b/modules/carousel/api/Carousel.php
@@ -2,6 +2,7 @@
 namespace yii\easyii\modules\carousel\api;
 
 use Yii;
+use yii\helpers\Url;
 use yii\easyii\helpers\Data;
 use yii\easyii\modules\carousel\models\Carousel as CarouselModel;
 
@@ -37,7 +38,7 @@ class Carousel extends \yii\easyii\components\API
     public function api_widget()
     {
         if(!count($this->_items)){
-            return '<a href="/admin/carousel/a/create" target="_blank">'.Yii::t('easyii/carousel/api', 'Create carousel').'</a>';
+            return '<a href="' . Url::to(['/admin/carousel/a/create']) . '" target="_blank">'.Yii::t('easyii/carousel/api', 'Create carousel').'</a>';
         }
 
         $widget = \yii\bootstrap\Carousel::widget([

--- a/modules/carousel/controllers/AController.php
+++ b/modules/carousel/controllers/AController.php
@@ -58,7 +58,7 @@ class AController extends Controller
 
                         if($model->save()){
                             $this->flash('success', Yii::t('easyii/carousel', 'Carousel created'));
-                            return $this->redirect('/admin/carousel');
+                            return $this->redirect(['/admin/carousel']);
                         }
                         else{
                             $this->flash('error', Yii::t('easyii', 'Create error. {0}', $model->formatErrors()));
@@ -87,7 +87,7 @@ class AController extends Controller
 
         if($model === null){
             $this->flash('error', Yii::t('easyii', 'Not found'));
-            return $this->redirect('/admin/carousel');
+            return $this->redirect(['/admin/carousel']);
         }
 
         if ($model->load(Yii::$app->request->post())) {

--- a/modules/carousel/views/a/_form.php
+++ b/modules/carousel/views/a/_form.php
@@ -7,7 +7,7 @@ use yii\widgets\ActiveForm;
     'options' => ['enctype' => 'multipart/form-data']
 ]); ?>
 <?php if($model->image) : ?>
-    <img src="<?= Yii::$app->request->baseUrl.$model->image ?>" style="width: 848px">
+    <img src="<?= $model->image ?>" style="width: 848px">
 <?php endif; ?>
 <?= $form->field($model, 'image')->fileInput() ?>
 <?php if($this->context->module->settings['enableTitle']) : ?>

--- a/modules/carousel/views/a/_menu.php
+++ b/modules/carousel/views/a/_menu.php
@@ -1,15 +1,17 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 <ul class="nav nav-pills">
     <li <?= ($action === 'index') ? 'class="active"' : '' ?>>
-        <a href="<?= $this->context->getReturnUrl('/admin/carousel') ?>">
+        <a href="<?= $this->context->getReturnUrl(['/admin/carousel']) ?>">
             <?php if($action === 'edit') : ?>
                 <i class="glyphicon glyphicon-chevron-left font-12"></i>
             <?php endif; ?>
             <?= Yii::t('easyii', 'List') ?>
         </a>
     </li>
-    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="/admin/<?= $this->context->module->id ?>/a/create"><?= Yii::t('easyii', 'Create') ?></a></li>
+    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/' . $this->context->module->id . '/a/create']) ?>"><?= Yii::t('easyii', 'Create') ?></a></li>
 </ul>
 <br/>

--- a/modules/carousel/views/a/index.php
+++ b/modules/carousel/views/a/index.php
@@ -1,6 +1,7 @@
 <?php
 use yii\easyii\modules\carousel\models\Carousel;
 use yii\helpers\Html;
+use yii\helpers\Url;
 
 $this->title = Yii::t('easyii/carousel', 'Carousel');
 ?>
@@ -25,19 +26,19 @@ $this->title = Yii::t('easyii/carousel', 'Carousel');
                 <?php if(IS_ROOT) : ?>
                     <td><?= $item->primaryKey ?></td>
                 <?php endif; ?>
-                <td><a href="/admin/carousel/a/edit/<?= $item->primaryKey ?>"><img src="<?= $item->image ?>" style="width: 550px;"></a></td>
+                <td><a href="<?= Url::to(['/admin/carousel/a/edit', 'id' => $item->primaryKey]) ?>"><img src="<?= $item->image ?>" style="width: 550px;"></a></td>
                 <td class="status vtop">
                     <?= Html::checkbox('', $item->status == Carousel::STATUS_ON, [
                         'class' => 'switch',
                         'data-id' => $item->primaryKey,
-                        'data-link' => '/admin/carousel/a/'
+                        'data-link' => Url::to(['/admin/carousel/a/']) . '/',
                     ]) ?>
                 </td>
                 <td>
                     <div class="btn-group btn-group-sm" role="group">
-                        <a href="/admin/carousel/a/up/<?= $item->primaryKey ?>" class="btn btn-default move-up" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
-                        <a href="/admin/carousel/a/down/<?= $item->primaryKey ?>" class="btn btn-default move-down" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
-                        <a href="/admin/carousel/a/delete/<?= $item->primaryKey ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
+                        <a href="<?= Url::to(['/admin/carousel/a/up', 'id' => $item->primaryKey]) ?>" class="btn btn-default move-up" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
+                        <a href="<?= Url::to(['/admin/carousel/a/down', 'id' => $item->primaryKey]) ?>" class="btn btn-default move-down" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
+                        <a href="<?= Url::to(['/admin/carousel/a/delete', 'id' => $item->primaryKey]) ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
                     </div>
                 </td>
             </tr>

--- a/modules/carousel/views/a/index.php
+++ b/modules/carousel/views/a/index.php
@@ -31,7 +31,7 @@ $this->title = Yii::t('easyii/carousel', 'Carousel');
                     <?= Html::checkbox('', $item->status == Carousel::STATUS_ON, [
                         'class' => 'switch',
                         'data-id' => $item->primaryKey,
-                        'data-link' => Url::to(['/admin/carousel/a/']) . '/',
+                        'data-link' => Url::to(['/admin/carousel/a/']),
                     ]) ?>
                 </td>
                 <td>

--- a/modules/catalog/api/Catalog.php
+++ b/modules/catalog/api/Catalog.php
@@ -3,6 +3,7 @@ namespace yii\easyii\modules\catalog\api;
 
 use Yii;
 use yii\data\ActiveDataProvider;
+use yii\helpers\Url;
 use yii\widgets\LinkPager;
 
 use yii\easyii\widgets\Fancybox;
@@ -223,7 +224,7 @@ class Catalog extends \yii\easyii\components\API
             return $this->createCatObject('');
         }
         elseif(preg_match(Category::$slugPattern, $id_slug)){
-            return $this->createCatObject('<a href="/admin/catalog/a/create/?slug='.$id_slug.'" target="_blank">'.Yii::t('easyii/catalog/api', 'Create category').'</a>');
+            return $this->createCatObject('<a href="' . Url::to(['/admin/catalog/a/create', 'slug' => $id_slug]) . '" target="_blank">'.Yii::t('easyii/catalog/api', 'Create category').'</a>');
         }
         else{
             return $this->createCatObject($this->errorText('WRONG CATEGORY IDENTIFIER'));

--- a/modules/catalog/controllers/AController.php
+++ b/modules/catalog/controllers/AController.php
@@ -64,7 +64,7 @@ class AController extends Controller
 
                 if($model->save()){
                     $this->flash('success', Yii::t('easyii/catalog', 'Category created'));
-                    return $this->redirect('/admin/catalog/a/fields/'.$model->primaryKey);
+                    return $this->redirect(['/admin/catalog/a/fields', 'id' => $model->primaryKey]);
                 }
                 else{
                     $this->flash('error', Yii::t('easyii', 'Create error. {0}', $model->formatErrors()));
@@ -84,7 +84,7 @@ class AController extends Controller
     public function actionEdit($id)
     {
         if(!($model = Category::findOne($id))){
-            return $this->redirect('/admin/catalog');
+            return $this->redirect(['/admin/catalog']);
         }
 
         if ($model->load(Yii::$app->request->post())) {
@@ -120,7 +120,7 @@ class AController extends Controller
     public function actionFields($id)
     {
         if(!($model = Category::findOne($id))){
-            return $this->redirect('/admin/catalog');
+            return $this->redirect(['/admin/catalog']);
         }
 
         if (Yii::$app->request->post('save'))

--- a/modules/catalog/controllers/ItemsController.php
+++ b/modules/catalog/controllers/ItemsController.php
@@ -27,7 +27,7 @@ class ItemsController extends Controller
     public function actionIndex($id)
     {
         if(!($model = Category::findOne($id))){
-            return $this->redirect('/admin/catalog');
+            return $this->redirect(['/admin/catalog']);
         }
 
         return $this->render('index', [
@@ -39,7 +39,7 @@ class ItemsController extends Controller
     public function actionCreate($id)
     {
         if(!($category = Category::findOne($id))){
-            return $this->redirect('/admin/catalog');
+            return $this->redirect(['/admin/catalog']);
         }
 
         $model = new Item;
@@ -64,7 +64,7 @@ class ItemsController extends Controller
 
                 if ($model->save()) {
                     $this->flash('success', Yii::t('easyii/catalog', 'Item created'));
-                    return $this->redirect('/admin/catalog/items/edit/' . $model->primaryKey);
+                    return $this->redirect(['/admin/catalog/items/edit/', 'id' => $model->primaryKey]);
                 } else {
                     $this->flash('error', Yii::t('easyii', 'Create error. {0}', $model->formatErrors()));
                     return $this->refresh();
@@ -83,7 +83,7 @@ class ItemsController extends Controller
     public function actionEdit($id)
     {
         if(!($model = Item::findOne($id))){
-            return $this->redirect('/admin/catalog');
+            return $this->redirect(['/admin/catalog']);
         }
 
         if ($model->load(Yii::$app->request->post())) {
@@ -105,7 +105,7 @@ class ItemsController extends Controller
 
                 if ($model->save()) {
                     $this->flash('success', Yii::t('easyii/catalog', 'Item updated'));
-                    return $this->redirect('/admin/catalog/items/edit/' . $model->primaryKey);
+                    return $this->redirect(['/admin/catalog/items/edit', 'id' => $model->primaryKey]);
                 } else {
                     $this->flash('error', Yii::t('easyii', 'Update error. {0}', $model->formatErrors()));
                     return $this->refresh();
@@ -123,7 +123,7 @@ class ItemsController extends Controller
     public function actionPhotos($id)
     {
         if(!($model = Item::findOne($id))){
-            return $this->redirect('/admin/catalog');
+            return $this->redirect(['/admin/catalog']);
         }
 
         return $this->render('photos', [

--- a/modules/catalog/views/a/_form.php
+++ b/modules/catalog/views/a/_form.php
@@ -1,5 +1,6 @@
 <?php
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\widgets\ActiveForm;
 use yii\easyii\widgets\SeoForm;
 
@@ -13,7 +14,7 @@ $settings = $this->context->module->settings;
 <?php if($settings['categoryThumb']) : ?>
     <?php if($model->thumb) : ?>
         <img src="<?= Yii::$app->request->baseUrl.$model->thumb ?>">
-        <a href="/admin/catalog/a/clear-image/<?= $model->primaryKey ?>" class="text-danger confirm-delete" title="<?= Yii::t('easyii/catalog', 'Clear image')?>"><?= Yii::t('easyii/catalog', 'Clear image')?></a>
+        <a href="<?= Url::to(['/admin/catalog/a/clear-image', 'id' => $model->primaryKey]) ?>" class="text-danger confirm-delete" title="<?= Yii::t('easyii/catalog', 'Clear image')?>"><?= Yii::t('easyii/catalog', 'Clear image')?></a>
     <?php endif; ?>
     <?= $form->field($model, 'thumb')->fileInput() ?>
 <?php endif; ?>

--- a/modules/catalog/views/a/_form.php
+++ b/modules/catalog/views/a/_form.php
@@ -13,7 +13,7 @@ $settings = $this->context->module->settings;
 <?= $form->field($model, 'title') ?>
 <?php if($settings['categoryThumb']) : ?>
     <?php if($model->thumb) : ?>
-        <img src="<?= Yii::$app->request->baseUrl.$model->thumb ?>">
+        <img src="<?= $model->thumb ?>">
         <a href="<?= Url::to(['/admin/catalog/a/clear-image', 'id' => $model->primaryKey]) ?>" class="text-danger confirm-delete" title="<?= Yii::t('easyii/catalog', 'Clear image')?>"><?= Yii::t('easyii/catalog', 'Clear image')?></a>
     <?php endif; ?>
     <?= $form->field($model, 'thumb')->fileInput() ?>

--- a/modules/catalog/views/a/_menu.php
+++ b/modules/catalog/views/a/_menu.php
@@ -1,23 +1,25 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 <?php if(IS_ROOT) : ?>
 <ul class="nav nav-pills">
     <li <?= ($action === 'index') ? 'class="active"' : '' ?>>
-        <a href="<?= $this->context->getReturnUrl('/admin/catalog') ?>">
+        <a href="<?= $this->context->getReturnUrl(['/admin/catalog']) ?>">
             <?php if($action === 'fields' || $action === 'edit') : ?>
                 <i class="glyphicon glyphicon-chevron-left font-12"></i>
             <?php endif; ?>
             <?= Yii::t('easyii/catalog', 'Categories') ?>
         </a>
     </li>
-    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="/admin/catalog/a/create"><?= Yii::t('easyii/catalog', 'Create category') ?></a></li>
+    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/catalog/a/create']) ?>"><?= Yii::t('easyii/catalog', 'Create category') ?></a></li>
 </ul>
 <br/>
 <?php elseif($action === 'edit') : ?>
     <ul class="nav nav-pills">
         <li>
-            <a href="<?= $this->context->getReturnUrl('/admin/catalog')?>">
+            <a href="<?= $this->context->getReturnUrl(['/admin/catalog'])?>">
                 <i class="glyphicon glyphicon-chevron-left font-12"></i>
                 <?= Yii::t('easyii/catalog', 'Categories') ?>
             </a>

--- a/modules/catalog/views/a/_submenu.php
+++ b/modules/catalog/views/a/_submenu.php
@@ -1,10 +1,12 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 <?php if(IS_ROOT) : ?>
     <ul class="nav nav-tabs">
-        <li <?= ($action === 'edit') ? 'class="active"' : '' ?>><a href="/admin/catalog/a/edit/<?= $model->primaryKey ?>"><?= Yii::t('easyii', 'Edit') ?></a></li>
-        <li <?= ($action === 'fields') ? 'class="active"' : '' ?>><a href="/admin/catalog/a/fields/<?= $model->primaryKey ?>"><span class="glyphicon glyphicon-cog"></span> <?= Yii::t('easyii/catalog', 'Fields') ?></a></li>
+        <li <?= ($action === 'edit') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/catalog/a/edit', 'id' => $model->primaryKey]) ?>"><?= Yii::t('easyii', 'Edit') ?></a></li>
+        <li <?= ($action === 'fields') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/catalog/a/fields', 'id' => $model->primaryKey]) ?>"><span class="glyphicon glyphicon-cog"></span> <?= Yii::t('easyii/catalog', 'Fields') ?></a></li>
     </ul>
     <br>
 <?php endif;?>

--- a/modules/catalog/views/a/index.php
+++ b/modules/catalog/views/a/index.php
@@ -33,7 +33,7 @@ $this->title = Yii::t('easyii/catalog', 'Catalog');
                     <?= Html::checkbox('', $item->status == Category::STATUS_ON, [
                         'class' => 'switch',
                         'data-id' => $item->primaryKey,
-                        'data-link' => Url::to(['/admin/catalog/a/']) . '/'
+                        'data-link' => Url::to(['/admin/catalog/a/']),
                     ]) ?>
                 </td>
                 <td class="control">

--- a/modules/catalog/views/a/index.php
+++ b/modules/catalog/views/a/index.php
@@ -1,5 +1,6 @@
 <?php
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\easyii\modules\catalog\models\Category;
 
 $this->title = Yii::t('easyii/catalog', 'Catalog');
@@ -26,22 +27,22 @@ $this->title = Yii::t('easyii/catalog', 'Catalog');
                 <?php if(IS_ROOT) : ?>
                     <td><?= $item->primaryKey ?></td>
                 <?php endif; ?>
-                <td><a href="/admin/catalog/items/<?= $item->primaryKey ?>"><?= $item->title ?></a></td>
+                <td><a href="<?= Url::to(['/admin/catalog/items', 'id' => $item->primaryKey]) ?>"><?= $item->title ?></a></td>
                 <td><?= $item->item_count ?></td>
                 <td class="status">
                     <?= Html::checkbox('', $item->status == Category::STATUS_ON, [
                         'class' => 'switch',
                         'data-id' => $item->primaryKey,
-                        'data-link' => '/admin/catalog/a/'
+                        'data-link' => Url::to(['/admin/catalog/a/']) . '/'
                     ]) ?>
                 </td>
                 <td class="control">
                     <div class="btn-group btn-group-sm" role="group">
-                        <a href="/admin/catalog/a/up/<?= $item->primaryKey ?>" class="btn btn-default move-up" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
-                        <a href="/admin/catalog/a/down/<?= $item->primaryKey ?>" class="btn btn-default move-down" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
-                        <a href="/admin/catalog/a/edit/<?= $item->primaryKey ?>" class="btn btn-default" title="<?= Yii::t('easyii/catalog', 'Edit category') ?>"><span class="glyphicon glyphicon-pencil"></span></a>
+                        <a href="<?= Url::to(['/admin/catalog/a/up', 'id' => $item->primaryKey]) ?>" class="btn btn-default move-up" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
+                        <a href="<?= Url::to(['/admin/catalog/a/down', 'id' => $item->primaryKey]) ?>" class="btn btn-default move-down" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
+                        <a href="<?= Url::to(['/admin/catalog/a/edit', 'id' => $item->primaryKey]) ?>" class="btn btn-default" title="<?= Yii::t('easyii/catalog', 'Edit category') ?>"><span class="glyphicon glyphicon-pencil"></span></a>
                         <?php if(IS_ROOT) : ?>
-                        <a href="/admin/catalog/a/delete/<?= $item->primaryKey ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
+                        <a href="<?= Url::to(['/admin/catalog/a/delete', 'id' => $item->primaryKey]) ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
                         <?php endif; ?>
                     </div>
                 </td>

--- a/modules/catalog/views/items/_form.php
+++ b/modules/catalog/views/items/_form.php
@@ -14,7 +14,7 @@ $settings = $this->context->module->settings;
 <?= $form->field($model, 'title') ?>
 <?php if($settings['itemThumb']) : ?>
     <?php if($model->thumb) : ?>
-        <img src="<?= Yii::$app->request->baseUrl.$model->thumb ?>">
+        <img src="<?= $model->thumb ?>">
         <a href="<?= Url::to(['/admin/catalog/items/clear-image', 'id' => $model->primaryKey]) ?>" class="text-danger confirm-delete" title="<?= Yii::t('easyii/catalog', 'Clear image')?>"><?= Yii::t('easyii/catalog', 'Clear image')?></a>
     <?php endif; ?>
     <?= $form->field($model, 'thumb')->fileInput() ?>

--- a/modules/catalog/views/items/_form.php
+++ b/modules/catalog/views/items/_form.php
@@ -1,5 +1,6 @@
 <?php
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\widgets\ActiveForm;
 use yii\easyii\widgets\Redactor;
 use yii\easyii\widgets\SeoForm;
@@ -14,7 +15,7 @@ $settings = $this->context->module->settings;
 <?php if($settings['itemThumb']) : ?>
     <?php if($model->thumb) : ?>
         <img src="<?= Yii::$app->request->baseUrl.$model->thumb ?>">
-        <a href="/admin/catalog/items/clear-image/<?= $model->primaryKey ?>" class="text-danger confirm-delete" title="<?= Yii::t('easyii/catalog', 'Clear image')?>"><?= Yii::t('easyii/catalog', 'Clear image')?></a>
+        <a href="<?= Url::to(['/admin/catalog/items/clear-image', 'id' => $model->primaryKey]) ?>" class="text-danger confirm-delete" title="<?= Yii::t('easyii/catalog', 'Clear image')?>"><?= Yii::t('easyii/catalog', 'Clear image')?></a>
     <?php endif; ?>
     <?= $form->field($model, 'thumb')->fileInput() ?>
 <?php endif; ?>
@@ -23,8 +24,8 @@ $settings = $this->context->module->settings;
     <?= $form->field($model, 'description')->widget(Redactor::className(),[
         'options' => [
             'minHeight' => 400,
-            'imageUpload' => '/admin/redactor/upload?dir=catalog',
-            'fileUpload' => '/admin/redactor/upload?dir=catalog',
+            'imageUpload' => Url::to(['/admin/redactor/upload', 'dir' => 'catalog'], true),
+            'fileUpload' => Url::to(['/admin/redactor/upload', 'dir' => 'catalog'], true),
             'plugins' => ['fullscreen']
         ]
     ]) ?>

--- a/modules/catalog/views/items/_menu.php
+++ b/modules/catalog/views/items/_menu.php
@@ -1,11 +1,13 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 <ul class="nav nav-pills">
     <?php if($action === 'index') : ?>
-        <li><a href="/admin/catalog"><i class="glyphicon glyphicon-chevron-left font-12"></i> <?= Yii::t('easyii/catalog', 'Categories') ?></a></li>
+        <li><a href="<?= Url::to(['/admin/catalog']) ?>"><i class="glyphicon glyphicon-chevron-left font-12"></i> <?= Yii::t('easyii/catalog', 'Categories') ?></a></li>
     <?php endif; ?>
-    <li <?= ($action === 'index') ? 'class="active"' : '' ?>><a href="/admin/catalog/items/<?= $category->primaryKey ?>"><?php if($action !== 'index') echo '<i class="glyphicon glyphicon-chevron-left font-12"></i> ' ?><?= $category->title ?></a></li>
-    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="/admin/catalog/items/create/<?= $category->primaryKey ?>"><?= Yii::t('easyii', 'Add') ?></a></li>
+    <li <?= ($action === 'index') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/catalog/items', 'id' => $category->primaryKey]) ?>"><?php if($action !== 'index') echo '<i class="glyphicon glyphicon-chevron-left font-12"></i> ' ?><?= $category->title ?></a></li>
+    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/catalog/items/create', 'id' => $category->primaryKey]) ?>"><?= Yii::t('easyii', 'Add') ?></a></li>
 </ul>
 <br/>

--- a/modules/catalog/views/items/_submenu.php
+++ b/modules/catalog/views/items/_submenu.php
@@ -1,9 +1,11 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 
 <ul class="nav nav-tabs">
-    <li <?= ($action === 'edit') ? 'class="active"' : '' ?>><a href="/admin/catalog/items/edit/<?= $model->primaryKey ?>"><?= Yii::t('easyii', 'Edit') ?></a></li>
-    <li <?= ($action === 'photos') ? 'class="active"' : '' ?>><a href="/admin/catalog/items/photos/<?= $model->primaryKey ?>"><span class="glyphicon glyphicon-camera"></span> <?= Yii::t('easyii', 'Photos') ?></a></li>
+    <li <?= ($action === 'edit') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/catalog/items/edit', 'id' => $model->primaryKey]) ?>"><?= Yii::t('easyii', 'Edit') ?></a></li>
+    <li <?= ($action === 'photos') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/catalog/items/photos', 'id' => $model->primaryKey]) ?>"><span class="glyphicon glyphicon-camera"></span> <?= Yii::t('easyii', 'Photos') ?></a></li>
 </ul>
 <br>

--- a/modules/catalog/views/items/index.php
+++ b/modules/catalog/views/items/index.php
@@ -1,4 +1,6 @@
 <?php
+use yii\helpers\Url;
+
 $this->title = Yii::t('easyii/catalog', 'Catalog');
 ?>
 <?= $this->render('_menu', ['category' => $model]) ?>
@@ -20,12 +22,12 @@ $this->title = Yii::t('easyii/catalog', 'Catalog');
                 <?php if(IS_ROOT) : ?>
                     <td><?= $item->primaryKey ?></td>
                 <?php endif; ?>
-                <td><a href="/admin/catalog/items/edit/<?= $item->primaryKey ?>"><?= $item->title ?></a></td>
+                <td><a href="<?= Url::to(['/admin/catalog/items/edit', 'id' => $item->primaryKey]) ?>"><?= $item->title ?></a></td>
                 <td class="text-right">
                     <div class="btn-group btn-group-sm" role="group">
-                        <a href="/admin/catalog/items/up/<?= $item->primaryKey ?>?category_id=<?= $model->primaryKey ?>" class="btn btn-default move-up" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
-                        <a href="/admin/catalog/items/down/<?= $item->primaryKey ?>?category_id=<?= $model->primaryKey ?>" class="btn btn-default move-down" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
-                        <a href="/admin/catalog/items/delete/<?= $item->primaryKey ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
+                        <a href="<?= Url::to(['/admin/catalog/items/up', 'id' => $item->primaryKey, 'category_id' => $model->primaryKey]) ?>" class="btn btn-default move-up" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
+                        <a href="<?= Url::to(['/admin/catalog/items/down', 'id' => $item->primaryKey, 'category_id' => $model->primaryKey]) ?>" class="btn btn-default move-down" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
+                        <a href="<?= Url::to(['/admin/catalog/items/delete', 'id' => $item->primaryKey]) ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
                     </div>
                 </td>
             </tr>

--- a/modules/faq/controllers/AController.php
+++ b/modules/faq/controllers/AController.php
@@ -50,7 +50,7 @@ class AController extends Controller
 
                 if($model->save()){
                     $this->flash('success', Yii::t('easyii/faq', 'Entry created'));
-                    return $this->redirect('/admin/faq');
+                    return $this->redirect(['/admin/faq']);
                 }
                 else{
                     $this->flash('error', Yii::t('easyii', 'Create error. {0}', $model->formatErrors()));
@@ -73,7 +73,7 @@ class AController extends Controller
 
         if($model === null){
             $this->flash('error', Yii::t('easyii', 'Not found'));
-            return $this->redirect('/admin/faq');
+            return $this->redirect(['/admin/faq']);
         }
 
         if ($model->load(Yii::$app->request->post())) {

--- a/modules/faq/views/a/_menu.php
+++ b/modules/faq/views/a/_menu.php
@@ -1,23 +1,25 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 <?php if(IS_ROOT) : ?>
 <ul class="nav nav-pills">
     <li <?= ($action === 'index') ? 'class="active"' : '' ?>>
-        <a href="<?= $this->context->getReturnUrl('/admin/faq') ?>">
+        <a href="<?= $this->context->getReturnUrl(['/admin/faq']) ?>">
             <?php if($action === 'edit') : ?>
                 <i class="glyphicon glyphicon-chevron-left font-12"></i>
             <?php endif; ?>
             <?= Yii::t('easyii', 'List') ?>
         </a>
     </li>
-    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="/admin/faq/a/create"><?= Yii::t('easyii/faq', 'Create entry') ?></a></li>
+    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/faq/a/create']) ?>"><?= Yii::t('easyii/faq', 'Create entry') ?></a></li>
 </ul>
 <br/>
 <?php elseif($action === 'edit') : ?>
     <ul class="nav nav-pills">
         <li>
-            <a href="<?= $this->context->getReturnUrl('/admin/faq')?>">
+            <a href="<?= $this->context->getReturnUrl(['/admin/faq'])?>">
                 <i class="glyphicon glyphicon-chevron-left font-12"></i>
                 <?= Yii::t('easyii/faq', 'FAQ') ?>
             </a>

--- a/modules/faq/views/a/index.php
+++ b/modules/faq/views/a/index.php
@@ -1,5 +1,6 @@
 <?php
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\helpers\StringHelper;
 use yii\easyii\modules\faq\models\Faq;
 
@@ -26,19 +27,19 @@ $this->title = Yii::t('easyii/faq', 'FAQ');
                 <?php if(IS_ROOT) : ?>
                     <td><?= $item->primaryKey ?></td>
                 <?php endif; ?>
-                <td><a href="/admin/faq/a/edit/<?= $item->primaryKey ?>"><?= StringHelper::truncate(strip_tags($item->question), 128) ?></a></td>
+                <td><a href="<?= Url::to(['/admin/faq/a/edit', 'id' => $item->primaryKey]) ?>"><?= StringHelper::truncate(strip_tags($item->question), 128) ?></a></td>
                 <td class="status vtop">
                     <?= Html::checkbox('', $item->status == Faq::STATUS_ON, [
                         'class' => 'switch',
                         'data-id' => $item->primaryKey,
-                        'data-link' => '/admin/faq/a/'
+                        'data-link' => Url::to(['/admin/faq/a/']) . '/',
                     ]) ?>
                 </td>
                 <td>
                     <div class="btn-group btn-group-sm" role="group">
-                        <a href="/admin/faq/a/up/<?= $item->primaryKey ?>" class="btn btn-default move-up" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
-                        <a href="/admin/faq/a/down/<?= $item->primaryKey ?>" class="btn btn-default move-down" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
-                        <a href="/admin/faq/a/delete/<?= $item->primaryKey ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
+                        <a href="<?= Url::to(['/admin/faq/a/up', 'id' => $item->primaryKey]) ?>" class="btn btn-default move-up" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
+                        <a href="<?= Url::to(['/admin/faq/a/down', 'id' => $item->primaryKey]) ?>" class="btn btn-default move-down" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
+                        <a href="<?= Url::to(['/admin/faq/a/delete', 'id' => $item->primaryKey]) ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
                     </div>
                 </td>
             </tr>

--- a/modules/faq/views/a/index.php
+++ b/modules/faq/views/a/index.php
@@ -32,7 +32,7 @@ $this->title = Yii::t('easyii/faq', 'FAQ');
                     <?= Html::checkbox('', $item->status == Faq::STATUS_ON, [
                         'class' => 'switch',
                         'data-id' => $item->primaryKey,
-                        'data-link' => Url::to(['/admin/faq/a/']) . '/',
+                        'data-link' => Url::to(['/admin/faq/a/']),
                     ]) ?>
                 </td>
                 <td>

--- a/modules/feedback/api/Feedback.php
+++ b/modules/feedback/api/Feedback.php
@@ -5,6 +5,7 @@ use Yii;
 use yii\easyii\modules\feedback\models\Feedback as FeedbackModel;
 
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\widgets\ActiveForm;
 use yii\bootstrap\Alert;
 use yii\easyii\widgets\ReCaptcha;
@@ -19,7 +20,7 @@ class Feedback extends \yii\easyii\components\API
         ob_start();
         $form = ActiveForm::begin([
             'enableClientValidation' => true,
-            'action' => '/admin/feedback/send'
+            'action' => Url::to(['/admin/feedback/send'])
         ]);
 
         switch(Yii::$app->session->getFlash(FeedbackModel::FLASH_KEY))

--- a/modules/feedback/controllers/AController.php
+++ b/modules/feedback/controllers/AController.php
@@ -61,7 +61,7 @@ class AController extends Controller
 
         if($model === null){
             $this->flash('error', Yii::t('easyii', 'Not found'));
-            return $this->redirect('/admin/feedback');
+            return $this->redirect(['/admin/feedback']);
         }
 
         if($model->status == Feedback::STATUS_NEW){

--- a/modules/feedback/views/a/_menu.php
+++ b/modules/feedback/views/a/_menu.php
@@ -1,10 +1,12 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 
 $backTo = null;
-$indexUrl = '/admin/feedback';
-$noanswerUrl = '/admin/feedback/a/noanswer';
-$allUrl = '/admin/feedback/a/all';
+$indexUrl = Url::to(['/admin/feedback/']);
+$noanswerUrl = Url::to(['/admin/feedback/a/noanswer']);
+$allUrl = Url::to(['/admin/feedback/a/all']);
 
 if($action === 'view')
 {
@@ -55,7 +57,7 @@ if($action === 'view')
     </li>
     <?php if($action === 'view' && isset($noanswer) && !$noanswer) : ?>
         <li class="pull-right">
-            <a href="/admin/feedback/a/set-answer/<?= Yii::$app->request->get('id') ?>" class="text-warning"><span class="glyphicon glyphicon-ok"></span> <?= Yii::t('easyii/feedback', 'Mark as answered') ?></a>
+            <a href="<?= Url::to(['/admin/feedback/a/set-answer', 'id' => Yii::$app->request->get('id')]) ?>" class="text-warning"><span class="glyphicon glyphicon-ok"></span> <?= Yii::t('easyii/feedback', 'Mark as answered') ?></a>
         </li>
     <?php endif; ?>    
 </ul>

--- a/modules/feedback/views/a/index.php
+++ b/modules/feedback/views/a/index.php
@@ -1,5 +1,6 @@
 <?php
 use yii\helpers\StringHelper;
+use yii\helpers\Url;
 use yii\easyii\modules\feedback\models\Feedback;
 
 $this->title = Yii::t('easyii/feedback', 'Feedback');
@@ -26,7 +27,7 @@ $this->title = Yii::t('easyii/feedback', 'Feedback');
                 <?php if(IS_ROOT) : ?>
                     <td><?= $item->primaryKey ?></td>
                 <?php endif; ?>
-                <td><a href="/admin/feedback/a/view/<?= $item->primaryKey ?>"><?= ($this->context->module->settings['enableTitle'] && $item->title != '') ? $item->title : StringHelper::truncate($item->text, 64, '...')?></a></td>
+                <td><a href="<?= Url::to(['/admin/feedback/a/view', 'id' => $item->primaryKey]) ?>"><?= ($this->context->module->settings['enableTitle'] && $item->title != '') ? $item->title : StringHelper::truncate($item->text, 64, '...')?></a></td>
                 <td><?= Yii::$app->formatter->asDatetime($item->time, 'short') ?></td>
                 <td>
                     <?php if($item->status == Feedback::STATUS_ANSWER) : ?>
@@ -35,7 +36,7 @@ $this->title = Yii::t('easyii/feedback', 'Feedback');
                         <span class="text-danger"><?= Yii::t('easyii', 'No') ?></span>
                     <?php endif; ?>
                 </td>
-                <td><a href="/admin/feedback/a/delete/<?= $item->primaryKey ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>
+                <td><a href="<?= Url::to(['/admin/feedback/a/delete', 'id' => $item->primaryKey]) ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>
             </tr>
     <?php endforeach; ?>
         </tbody>

--- a/modules/file/api/File.php
+++ b/modules/file/api/File.php
@@ -3,6 +3,7 @@ namespace yii\easyii\modules\file\api;
 
 use Yii;
 use yii\data\ActiveDataProvider;
+use yii\helpers\Url;
 use yii\easyii\modules\file\models\File as FileModel;
 use yii\widgets\LinkPager;
 
@@ -48,7 +49,7 @@ class File extends \yii\easyii\components\API
             $result[] = $this->parseFile($file);
         }
         if(!count($result)) {
-            $result[] = $this->createObject('<a href="/admin/file/a/create" target="_blank">'.Yii::t('easyii/file/api', 'Create file').'</a>');
+            $result[] = $this->createObject('<a href="' . Url::to(['/admin/file/a/create']) . '" target="_blank">'.Yii::t('easyii/file/api', 'Create file').'</a>');
             return $limit > 1 ? $result : $result[0];
         }
 
@@ -125,8 +126,8 @@ class File extends \yii\easyii\components\API
             'slug' => $is_string ? '' : $data['slug'],
             'bytes' => $is_string ? '' : $data['size'],
             'size' => $is_string ? '' : Yii::$app->formatter->asShortSize($data['size'], 2),
-            'file' => $is_string ? '' : '/admin/file/download/'.$data['file_id'],
-            'link' => $is_string ? $data : '<a href="/admin/file/download/'.$data['file_id'].'" class="easyiicms-file" target="_blank">'.$data['title'].'</a>',
+            'file' => $is_string ? '' : Url::to(['/admin/file/download', 'id' => $data['file_id']),
+            'link' => $is_string ? $data : '<a href="' . Url::to(['/admin/file/download', 'id' => $data['file_id']]) . '" class="easyiicms-file" target="_blank">'.$data['title'].'</a>',
             'downloads' => $is_string ? '' : $data['downloads'],
             'time' => $is_string ? '' : $data['time'],
             'date' => $is_string ? '' : Yii::$app->formatter->asDatetime($data['time'], 'medium'),
@@ -140,7 +141,7 @@ class File extends \yii\easyii\components\API
             return $this->createObject('');
         }
         elseif(preg_match(FileModel::$slugPattern, $id_slug)){
-            return $this->createObject('<a href="/admin/file/a/create/?slug='.$id_slug.'" target="_blank">'.Yii::t('easyii/file/api', 'Create file').'</a>');
+            return $this->createObject('<a href="' . Url::to(['/admin/file/a/create', 'slug' => $id_slug]) . '" target="_blank">'.Yii::t('easyii/file/api', 'Create file').'</a>');
         }
         else{
             return $this->createObject($this->errorText('WRONG FILE IDENTIFIER'));

--- a/modules/file/controllers/AController.php
+++ b/modules/file/controllers/AController.php
@@ -52,7 +52,7 @@ class AController extends Controller
 
                         if($model->save()){
                             $this->flash('success', Yii::t('easyii/file', 'File created'));
-                            return $this->redirect('/admin/file');
+                            return $this->redirect(['/admin/file/']);
                         }
                         else{
                             $this->flash('error', Yii::t('easyii', 'Create error. {0}', $model->formatErrors()));
@@ -83,7 +83,7 @@ class AController extends Controller
 
         if($model === null){
             $this->flash('error', Yii::t('easyii', 'Not found'));
-            return $this->redirect('/admin/file');
+            return $this->redirect(['/admin/file/']);
         }
 
         if ($model->load(Yii::$app->request->post())) {

--- a/modules/file/views/a/_menu.php
+++ b/modules/file/views/a/_menu.php
@@ -1,15 +1,17 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 <ul class="nav nav-pills">
     <li <?= ($action === 'index') ? 'class="active"' : '' ?>>
-        <a href="<?= $this->context->getReturnUrl('/admin/file') ?>">
+        <a href="<?= $this->context->getReturnUrl(['/admin/file']) ?>">
             <?php if($action === 'edit') : ?>
                 <i class="glyphicon glyphicon-chevron-left font-12"></i>
             <?php endif; ?>
             <?= Yii::t('easyii', 'List') ?>
         </a>
     </li>
-    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="/admin/file/a/create"><?= Yii::t('easyii', 'Create') ?></a></li>
+    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/file/a/create']) ?>"><?= Yii::t('easyii', 'Create') ?></a></li>
 </ul>
 <br/>

--- a/modules/file/views/a/index.php
+++ b/modules/file/views/a/index.php
@@ -1,4 +1,6 @@
 <?php
+use yii\helpers\Url;
+
 $this->title = Yii::t('easyii/file', 'Files');
 ?>
 
@@ -24,15 +26,15 @@ $this->title = Yii::t('easyii/file', 'Files');
                 <?php if(IS_ROOT) : ?>
                     <td><?= $item->primaryKey ?></td>
                 <?php endif; ?>
-                <td><a href="/admin/file/a/edit/<?= $item->primaryKey ?>"><?= $item->title ?></a></td>
+                <td><a href="<?= Url::to(['/admin/file/a/edit', 'id' => $item->primaryKey]) ?>"><?= $item->title ?></a></td>
                 <td><?= Yii::$app->formatter->asShortSize($item->size, 2) ?></td>
                 <td><?= $item->downloads ?></td>
                 <td><?= Yii::$app->formatter->asDatetime($item->time, 'short') ?></td>
                 <td class="control">
                     <div class="btn-group btn-group-sm" role="group">
-                        <a href="/admin/file/a/up/<?= $item->primaryKey ?>" class="btn btn-default move-up" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
-                        <a href="/admin/file/a/down/<?= $item->primaryKey ?>" class="btn btn-default move-down" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
-                        <a href="/admin/file/a/delete/<?= $item->primaryKey ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
+                        <a href="<?= Url::to(['/admin/file/a/up', 'id' => $item->primaryKey]) ?>" class="btn btn-default move-up" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
+                        <a href="<?= Url::to(['/admin/file/a/down', 'id' => $item->primaryKey]) ?>" class="btn btn-default move-down" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
+                        <a href="<?= Url::to(['/admin/file/a/delete', 'id' => $item->primaryKey]) ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
                     </div>
                 </td>
             </tr>

--- a/modules/gallery/api/Gallery.php
+++ b/modules/gallery/api/Gallery.php
@@ -3,6 +3,7 @@ namespace yii\easyii\modules\gallery\api;
 
 use Yii;
 use yii\data\ActiveDataProvider;
+use yii\helpers\Url;
 use yii\widgets\LinkPager;
 
 use yii\easyii\models\Photo;
@@ -196,7 +197,7 @@ class Gallery extends \yii\easyii\components\API
             return $this->createObject('');
         }
         elseif(preg_match(Album::$slugPattern, $id_slug)){
-            return $this->createObject('<a href="/admin/gallery/a/create/?slug='.$id_slug.'" target="_blank">'.Yii::t('easyii/gallery/api', 'Create album').'</a>');
+            return $this->createObject('<a href="' . Url::to(['/admin/gallery/a/create', 'slug' => $id_slug]) . '" target="_blank">'.Yii::t('easyii/gallery/api', 'Create album').'</a>');
         }
         else{
             return $this->createObject($this->errorText('WRONG ALBUM IDENTIFIER'));

--- a/modules/gallery/controllers/AController.php
+++ b/modules/gallery/controllers/AController.php
@@ -60,7 +60,7 @@ class AController extends Controller
 
                 if($model->save()){
                     $this->flash('success', Yii::t('easyii/gallery', 'Album created'));
-                    return $this->redirect('/admin/gallery/a/photos/'.$model->primaryKey);
+                    return $this->redirect(['/admin/gallery/a/photos', 'id' => $model->primaryKey]);
                 }
                 else{
                     $this->flash('error', Yii::t('easyii', 'Create error. {0}', $model->formatErrors()));
@@ -84,7 +84,7 @@ class AController extends Controller
 
         if($model === null){
             $this->flash('error', Yii::t('easyii', 'Not found'));
-            return $this->redirect('/admin/gallery');
+            return $this->redirect(['/admin/gallery']);
         }
 
         if ($model->load(Yii::$app->request->post())) {
@@ -121,7 +121,7 @@ class AController extends Controller
     public function actionPhotos($id)
     {
         if(!($model = Album::findOne($id))){
-            return $this->redirect('/admin/gallery');
+            return $this->redirect(['/admin/gallery']);
         }
 
         return $this->render('photos', [

--- a/modules/gallery/views/a/_form.php
+++ b/modules/gallery/views/a/_form.php
@@ -1,5 +1,6 @@
 <?php
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\widgets\ActiveForm;
 use yii\easyii\widgets\SeoForm;
 ?>
@@ -10,8 +11,8 @@ use yii\easyii\widgets\SeoForm;
 <?= $form->field($model, 'title') ?>
 <?php if($this->context->module->settings['albumThumb']) : ?>
     <?php if($model->thumb) : ?>
-        <img src="<?= Yii::$app->request->baseUrl.$model->thumb ?>">
-        <a href="/admin/gallery/a/clear-image/<?= $model->primaryKey ?>" class="text-danger confirm-delete" title="<?= Yii::t('easyii/gallery', 'Clear image')?>"><?= Yii::t('easyii/gallery', 'Clear image')?></a>
+        <img src="<?= $model->thumb ?>">
+        <a href="<?= Url::to(['/admin/gallery/a/clear-image', 'id' => $model->primaryKey]) ?>" class="text-danger confirm-delete" title="<?= Yii::t('easyii/gallery', 'Clear image')?>"><?= Yii::t('easyii/gallery', 'Clear image')?></a>
     <?php endif; ?>
     <?= $form->field($model, 'thumb')->fileInput() ?>
 <?php endif; ?>

--- a/modules/gallery/views/a/_menu.php
+++ b/modules/gallery/views/a/_menu.php
@@ -1,15 +1,17 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 <ul class="nav nav-pills">
     <li <?= ($action === 'index') ? 'class="active"' : '' ?>>
-        <a href="<?= $this->context->getReturnUrl('/admin/gallery') ?>">
+        <a href="<?= $this->context->getReturnUrl(['/admin/gallery']) ?>">
             <?php if($action === 'edit' || $action === 'photos') : ?>
                 <i class="glyphicon glyphicon-chevron-left font-12"></i>
             <?php endif; ?>
             <?= Yii::t('easyii/gallery', 'Albums') ?>
         </a>
     </li>
-    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="/admin/gallery/a/create"><?= Yii::t('easyii', 'Create') ?></a></li>
+    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/gallery/a/create']) ?>"><?= Yii::t('easyii', 'Create') ?></a></li>
 </ul>
 <br/>

--- a/modules/gallery/views/a/_submenu.php
+++ b/modules/gallery/views/a/_submenu.php
@@ -1,9 +1,11 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 
 <ul class="nav nav-tabs">
-    <li <?= ($action === 'photos') ? 'class="active"' : '' ?>><a href="/admin/gallery/a/photos/<?= $model->primaryKey ?>"><span class="glyphicon glyphicon-camera"></span> <?= Yii::t('easyii', 'Photos') ?></a></li>
-    <li <?= ($action === 'edit') ? 'class="active"' : '' ?>><a href="/admin/gallery/a/edit/<?= $model->primaryKey ?>"><?= Yii::t('easyii/gallery', 'Edit album') ?></a></li>
+    <li <?= ($action === 'photos') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/gallery/a/photos', 'id' => $model->primaryKey]) ?>"><span class="glyphicon glyphicon-camera"></span> <?= Yii::t('easyii', 'Photos') ?></a></li>
+    <li <?= ($action === 'edit') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/gallery/a/edit', 'id' => $model->primaryKey]) ?>"><?= Yii::t('easyii/gallery', 'Edit album') ?></a></li>
 </ul>
 <br>

--- a/modules/gallery/views/a/index.php
+++ b/modules/gallery/views/a/index.php
@@ -1,6 +1,7 @@
 <?php
 use yii\easyii\modules\gallery\models\Album;
 use yii\helpers\Html;
+use yii\helpers\Url;
 
 $this->title = Yii::t('easyii/gallery', 'Gallery');
 ?>
@@ -26,7 +27,7 @@ $this->title = Yii::t('easyii/gallery', 'Gallery');
                 <?php if(IS_ROOT) : ?>
                     <td><?= $item->primaryKey ?></td>
                 <?php endif; ?>
-                <td><a href="/admin/gallery/a/photos/<?= $item->primaryKey ?>"><?= $item->title ?></a></td>
+                <td><a href="<?= Url::to(['/admin/gallery/a/photos', 'id' => $item->primaryKey]) ?>"><?= $item->title ?></a></td>
                 <td><?= $item->photo_count ?></td>
                 <td class="status">
                     <?= Html::checkbox('', $item->status == Album::STATUS_ON, [
@@ -37,10 +38,10 @@ $this->title = Yii::t('easyii/gallery', 'Gallery');
                 </td>
                 <td class="control">
                     <div class="btn-group btn-group-sm" role="group">
-                        <a href="/admin/gallery/a/up/<?= $item->primaryKey ?>" class="btn btn-default move-up" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
-                        <a href="/admin/gallery/a/down/<?= $item->primaryKey ?>" class="btn btn-default move-down" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
-                        <a href="/admin/gallery/a/edit/<?= $item->primaryKey ?>" class="btn btn-default" title="<?= Yii::t('easyii', 'Edit category') ?>"><span class="glyphicon glyphicon-pencil"></span></a>
-                        <a href="/admin/gallery/a/delete/<?= $item->primaryKey ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
+                        <a href="<?= Url::to(['/admin/gallery/a/up', 'id' => $item->primaryKey]) ?>" class="btn btn-default move-up" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
+                        <a href="<?= Url::to(['/admin/gallery/a/down', 'id' => $item->primaryKey]) ?>" class="btn btn-default move-down" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
+                        <a href="<?= Url::to(['/admin/gallery/a/edit', 'id' => $item->primaryKey]) ?>" class="btn btn-default" title="<?= Yii::t('easyii', 'Edit category') ?>"><span class="glyphicon glyphicon-pencil"></span></a>
+                        <a href="<?= Url::to(['/admin/gallery/a/delete', 'id' => $item->primaryKey]) ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
                     </div>
                 </td>
             </tr>

--- a/modules/guestbook/api/Guestbook.php
+++ b/modules/guestbook/api/Guestbook.php
@@ -5,6 +5,7 @@ use Yii;
 use yii\data\ActiveDataProvider;
 use yii\widgets\LinkPager;
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\widgets\ActiveForm;
 use yii\bootstrap\Alert;
 
@@ -29,7 +30,7 @@ class Guestbook extends \yii\easyii\components\API
         ob_start();
         $form = ActiveForm::begin([
             'enableClientValidation' => true,
-            'action' => '/admin/guestbook/send'
+            'action' => Url::to(['/admin/guestbook/send']),
         ]);
 
         switch(Yii::$app->session->getFlash(GuestbookModel::FLASH_KEY)){

--- a/modules/guestbook/controllers/AController.php
+++ b/modules/guestbook/controllers/AController.php
@@ -60,7 +60,7 @@ class AController extends Controller
 
         if($model === null){
             $this->flash('error', Yii::t('easyii', 'Not found'));
-            return $this->redirect('/admin/guestbook');
+            return $this->redirect(['/admin/guestbook']);
         }
 
         if($model->new > 0){
@@ -123,7 +123,7 @@ class AController extends Controller
                 $this->flash('error', Yii::t('easyii', 'Update error. {0}', $model->formatErrors()));
             }
         }
-        return $this->redirect($this->getReturnUrl('/admin/guestbook'));
+        return $this->redirect($this->getReturnUrl(['/admin/guestbook']));
     }
 
     public function actionOn($id)

--- a/modules/guestbook/views/a/_menu.php
+++ b/modules/guestbook/views/a/_menu.php
@@ -1,13 +1,15 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 
 $backTo = null;
-$indexUrl = '/admin/guestbook';
-$noanswerUrl = '/admin/guestbook/a/noanswer';
+$indexUrl = Url::to(['/admin/guestbook']);
+$noanswerUrl = Url::to(['/admin/guestbook/a/noanswer']);
 
 if($action === 'view')
 {
-    $returnUrl = $this->context->getReturnUrl('/admin/guestbook');
+    $returnUrl = $this->context->getReturnUrl(['/admin/guestbook']);
 
     if(strpos($returnUrl, 'noanswer') !== false){
         $backTo = 'noanswer';
@@ -40,9 +42,9 @@ if($action === 'view')
     </li>
     <li class="pull-right">
         <?php if($action === 'view') : ?>
-            <a href="/admin/guestbook/a/setnew/<?= Yii::$app->request->get('id') ?>" class="text-warning"><span class="glyphicon glyphicon-eye-close"></span> <?= Yii::t('easyii/guestbook', 'Mark as new') ?></a>
+            <a href="<?= Url::to(['/admin/guestbook/a/setnew', 'id' => Yii::$app->request->get('id')]) ?>" class="text-warning"><span class="glyphicon glyphicon-eye-close"></span> <?= Yii::t('easyii/guestbook', 'Mark as new') ?></a>
         <?php else : ?>
-            <a href="/admin/guestbook/a/viewall" class="text-warning"><span class="glyphicon glyphicon-eye-open"></span> <?= Yii::t('easyii/guestbook', 'Mark all as viewed') ?></a>
+            <a href="<?= Url::to(['/admin/guestbook/a/viewall']) ?>" class="text-warning"><span class="glyphicon glyphicon-eye-open"></span> <?= Yii::t('easyii/guestbook', 'Mark all as viewed') ?></a>
         <?php endif; ?>
     </li>
 </ul>

--- a/modules/guestbook/views/a/index.php
+++ b/modules/guestbook/views/a/index.php
@@ -1,6 +1,7 @@
 <?php
 use yii\helpers\Html;
 use yii\helpers\StringHelper;
+use yii\helpers\Url;
 use yii\easyii\modules\guestbook\models\Guestbook;
 
 $this->title = Yii::t('easyii/guestbook', 'Guestbook');
@@ -32,7 +33,7 @@ $this->title = Yii::t('easyii/guestbook', 'Guestbook');
                     <?php if($item->new) : ?>
                         <span class="label label-warning">NEW</span>
                     <?php endif; ?>
-                    <a href="/admin/guestbook/a/view/<?= $item->primaryKey ?>">
+                    <a href="<?= Url::to(['/admin/guestbook/a/view', 'id' => $item->primaryKey]) ?>">
                         <?= ($item->title != '') ? $item->title : StringHelper::truncate($item->text, 120, '...') ?>
                     </a>
                 </td>
@@ -48,10 +49,10 @@ $this->title = Yii::t('easyii/guestbook', 'Guestbook');
                     <?= Html::checkbox('', $item->status == Guestbook::STATUS_ON, [
                         'class' => 'switch',
                         'data-id' => $item->primaryKey,
-                        'data-link' => '/admin/guestbook/a/'
+                        'data-link' => Url::to(['/admin/guestbook/a/']) . '/',
                     ]) ?>
                 </td>
-                <td class="control"><a href="/admin/guestbook/a/delete/<?= $item->primaryKey ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>
+                <td class="control"><a href="<?= Url::to(['/admin/guestbook/a/delete', 'id' => $item->primaryKey]) ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>
             </tr>
     <?php endforeach; ?>
         </tbody>

--- a/modules/guestbook/views/a/index.php
+++ b/modules/guestbook/views/a/index.php
@@ -49,7 +49,7 @@ $this->title = Yii::t('easyii/guestbook', 'Guestbook');
                     <?= Html::checkbox('', $item->status == Guestbook::STATUS_ON, [
                         'class' => 'switch',
                         'data-id' => $item->primaryKey,
-                        'data-link' => Url::to(['/admin/guestbook/a/']) . '/',
+                        'data-link' => Url::to(['/admin/guestbook/a/']),
                     ]) ?>
                 </td>
                 <td class="control"><a href="<?= Url::to(['/admin/guestbook/a/delete', 'id' => $item->primaryKey]) ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>

--- a/modules/news/api/News.php
+++ b/modules/news/api/News.php
@@ -3,6 +3,7 @@ namespace yii\easyii\modules\news\api;
 
 use Yii;
 use yii\data\ActiveDataProvider;
+use yii\helpers\Url;
 use yii\widgets\LinkPager;
 
 use yii\easyii\modules\news\models\News as NewsModel;
@@ -40,7 +41,7 @@ class News extends \yii\easyii\components\API
             $result[] = $this->parseNews($news);
         }
         if(!count($result)) {
-            $result[] = $this->createObject('<a href="/admin/news/a/create" target="_blank">'.Yii::t('easyii/news/api', 'Create news').'</a>');
+            $result[] = $this->createObject('<a href="' . Url::to(['/admin/news/a/create']) . '" target="_blank">'.Yii::t('easyii/news/api', 'Create news').'</a>');
             return $limit > 1 ? $result : $result[0];
         }
 

--- a/modules/news/controllers/AController.php
+++ b/modules/news/controllers/AController.php
@@ -57,7 +57,7 @@ class AController extends Controller
 
                 if($model->save()){
                     $this->flash('success', Yii::t('easyii/news', 'News created'));
-                    return $this->redirect('/admin/news');
+                    return $this->redirect(['/admin/news']);
                 }
                 else{
                     $this->flash('error', Yii::t('easyii', 'Create error. {0}', $model->formatErrors()));
@@ -78,7 +78,7 @@ class AController extends Controller
 
         if($model === null){
             $this->flash('error', Yii::t('easyii', 'Not found'));
-            return $this->redirect('/admin/news');
+            return $this->redirect(['/admin/news']);
         }
 
         if ($model->load(Yii::$app->request->post())) {

--- a/modules/news/views/a/_form.php
+++ b/modules/news/views/a/_form.php
@@ -1,5 +1,6 @@
 <?php
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\widgets\ActiveForm;
 use yii\easyii\widgets\Redactor;
 use yii\easyii\widgets\SeoForm;
@@ -12,7 +13,7 @@ use yii\easyii\widgets\SeoForm;
 <?php if($this->context->module->settings['enableThumb']) : ?>
     <?php if($model->thumb) : ?>
         <img src="<?= Yii::$app->request->baseUrl.$model->thumb ?>">
-        <a href="/admin/news/a/clear-image/<?= $model->news_id ?>" class="text-danger confirm-delete" title="<?= Yii::t('easyii/news', 'Clear image')?>"><?= Yii::t('easyii/news', 'Clear image')?></a>
+        <a href="'<?= Url::to(['/admin/news/a/clear-image', 'id' => $model->news_id]) ?>" class="text-danger confirm-delete" title="<?= Yii::t('easyii/news', 'Clear image')?>"><?= Yii::t('easyii/news', 'Clear image')?></a>
     <?php endif; ?>
     <?= $form->field($model, 'thumb')->fileInput() ?>
 <?php endif; ?>
@@ -22,8 +23,8 @@ use yii\easyii\widgets\SeoForm;
 <?= $form->field($model, 'text')->widget(Redactor::className(),[
     'options' => [
         'minHeight' => 400,
-        'imageUpload' => '/admin/redactor/upload?dir=news',
-        'fileUpload' => '/admin/redactor/upload?dir=news',
+        'imageUpload' => Url::to(['/admin/redactor/upload', 'dir' => 'news']),
+        'fileUpload' => Url::to(['/admin/redactor/upload', 'dir' => 'news']),
         'plugins' => ['fullscreen']
     ]
 ]) ?>

--- a/modules/news/views/a/_menu.php
+++ b/modules/news/views/a/_menu.php
@@ -1,15 +1,17 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 <ul class="nav nav-pills">
     <li <?= ($action === 'index') ? 'class="active"' : '' ?>>
-        <a href="<?= $this->context->getReturnUrl('/admin/news') ?>">
+        <a href="<?= $this->context->getReturnUrl(['/admin/news']) ?>">
             <?php if($action === 'edit') : ?>
                 <i class="glyphicon glyphicon-chevron-left font-12"></i>
             <?php endif; ?>
             <?= Yii::t('easyii', 'List') ?>
         </a>
     </li>
-    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="/admin/news/a/create"><?= Yii::t('easyii', 'Create') ?></a></li>
+    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/news/a/create']) ?>"><?= Yii::t('easyii', 'Create') ?></a></li>
 </ul>
 <br/>

--- a/modules/news/views/a/index.php
+++ b/modules/news/views/a/index.php
@@ -33,7 +33,7 @@ $this->title = Yii::t('easyii/news', 'News');
                     <?= Html::checkbox('', $item->status == News::STATUS_ON, [
                         'class' => 'switch',
                         'data-id' => $item->primaryKey,
-                        'data-link' => Url::to(['/admin/news/a/']) . '/',
+                        'data-link' => Url::to(['/admin/news/a/']),
                     ]) ?>
                 </td>
                 <td class="control"><a href="<?= Url::to(['/admin/news/a/delete', 'id' => $item->primaryKey]) ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>

--- a/modules/news/views/a/index.php
+++ b/modules/news/views/a/index.php
@@ -1,6 +1,7 @@
 <?php
 use yii\easyii\modules\news\models\News;
 use yii\helpers\Html;
+use yii\helpers\Url;
 
 $this->title = Yii::t('easyii/news', 'News');
 ?>
@@ -26,16 +27,16 @@ $this->title = Yii::t('easyii/news', 'News');
                 <?php if(IS_ROOT) : ?>
                     <td><?= $item->primaryKey ?></td>
                 <?php endif; ?>
-                <td><a href="/admin/news/a/edit/<?= $item->primaryKey ?>"><?= $item->title ?></a></td>
+                <td><a href="<?= Url::to(['/admin/news/a/edit/', 'id' => $item->primaryKey]) ?>"><?= $item->title ?></a></td>
                 <td><?= $item->views ?></td>
                 <td class="status">
                     <?= Html::checkbox('', $item->status == News::STATUS_ON, [
                         'class' => 'switch',
                         'data-id' => $item->primaryKey,
-                        'data-link' => '/admin/news/a/'
+                        'data-link' => Url::to(['/admin/news/a/']) . '/',
                     ]) ?>
                 </td>
-                <td class="control"><a href="/admin/news/a/delete/<?= $item->primaryKey ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>
+                <td class="control"><a href="<?= Url::to(['/admin/news/a/delete', 'id' => $item->primaryKey]) ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>
             </tr>
     <?php endforeach; ?>
         </tbody>

--- a/modules/page/api/Page.php
+++ b/modules/page/api/Page.php
@@ -2,6 +2,7 @@
 namespace yii\easyii\modules\page\api;
 
 use Yii;
+use yii\helpers\Url;
 use yii\easyii\modules\page\models\Page as PageModel;
 
 class Page extends \yii\easyii\components\API
@@ -63,7 +64,7 @@ class Page extends \yii\easyii\components\API
             return $this->createObject('');
         }
         elseif(preg_match(PageModel::$slugPattern, $id_slug)){
-            return $this->createObject('<a href="/admin/page/a/create/?slug='.$id_slug.'" target="_blank">'.Yii::t('easyii/page/api', 'Create page').'</a>');
+            return $this->createObject('<a href="' . Url::to(['/admin/page/a/create', 'slug' => $id_slug]) . '" target="_blank">'.Yii::t('easyii/page/api', 'Create page').'</a>');
         }
         else{
             return $this->createObject($this->errorText('WRONG PAGE IDENTIFIER'));

--- a/modules/page/controllers/AController.php
+++ b/modules/page/controllers/AController.php
@@ -34,7 +34,7 @@ class AController extends Controller
             else{
                 if($model->save()){
                     $this->flash('success', Yii::t('easyii/page', 'Page created'));
-                    return $this->redirect('/admin/page');
+                    return $this->redirect(['/admin/page']);
                 }
                 else{
                     $this->flash('error', Yii::t('easyii', 'Create error. {0}', $model->formatErrors()));
@@ -57,7 +57,7 @@ class AController extends Controller
 
         if($model === null){
             $this->flash('error', Yii::t('easyii', 'Not found'));
-            return $this->redirect('/admin/page');
+            return $this->redirect(['/admin/page']);
         }
 
         if ($model->load(Yii::$app->request->post())) {

--- a/modules/page/views/a/_form.php
+++ b/modules/page/views/a/_form.php
@@ -1,5 +1,6 @@
 <?php
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\widgets\ActiveForm;
 use yii\easyii\widgets\Redactor;
 use yii\easyii\widgets\SeoForm;
@@ -11,8 +12,8 @@ use yii\easyii\widgets\SeoForm;
 <?= $form->field($model, 'text')->widget(Redactor::className(),[
     'options' => [
         'minHeight' => 400,
-        'imageUpload' => '/admin/redactor/upload?dir=pages',
-        'fileUpload' => '/admin/redactor/upload?dir=pages',
+        'imageUpload' => Url::to(['/admin/redactor/upload', 'dir' => 'pages']),
+        'fileUpload' => Url::to(['/admin/redactor/upload', 'dir' => 'pages']),
         'plugins' => ['fullscreen']
     ]
 ]) ?>

--- a/modules/page/views/a/_menu.php
+++ b/modules/page/views/a/_menu.php
@@ -1,23 +1,25 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 <?php if(IS_ROOT) : ?>
 <ul class="nav nav-pills">
     <li <?= ($action === 'index') ? 'class="active"' : '' ?>>
-        <a href="<?= $this->context->getReturnUrl('/admin/page') ?>">
+        <a href="<?= $this->context->getReturnUrl(['/admin/page']) ?>">
             <?php if($action === 'edit') : ?>
                 <i class="glyphicon glyphicon-chevron-left font-12"></i>
             <?php endif; ?>
             <?= Yii::t('easyii', 'List') ?>
         </a>
     </li>
-    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="/admin/page/a/create"><?= Yii::t('easyii', 'Create') ?></a></li>
+    <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/page/a/create']) ?>"><?= Yii::t('easyii', 'Create') ?></a></li>
 </ul>
 <br/>
 <?php elseif($action === 'edit') : ?>
     <ul class="nav nav-pills">
         <li>
-            <a href="<?= $this->context->getReturnUrl('/admin/page')?>">
+            <a href="<?= $this->context->getReturnUrl(['/admin/page'])?>">
                 <i class="glyphicon glyphicon-chevron-left font-12"></i>
                 <?= Yii::t('easyii/page', 'Pages') ?>
             </a>

--- a/modules/page/views/a/index.php
+++ b/modules/page/views/a/index.php
@@ -1,4 +1,6 @@
 <?php
+use yii\helpers\Url;
+
 $this->title = Yii::t('easyii/page', 'Pages');
 ?>
 
@@ -24,10 +26,10 @@ $this->title = Yii::t('easyii/page', 'Pages');
                 <?php if(IS_ROOT) : ?>
                     <td><?= $item->primaryKey ?></td>
                 <?php endif; ?>
-                <td><a href="/admin/page/a/edit/<?= $item->primaryKey ?>"><?= $item->title ?></a></td>
+                <td><a href="<?= Url::to(['/admin/page/a/edit', 'id' => $item->primaryKey]) ?>"><?= $item->title ?></a></td>
                 <?php if(IS_ROOT) : ?>
                     <td><?= $item->slug ?></td>
-                    <td><a href="/admin/page/a/delete/<?= $item->primaryKey ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item')?>"></a></td>
+                    <td><a href="<?= Url::to(['/admin/page/a/delete', 'id' => $item->primaryKey]) ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item')?>"></a></td>
                 <?php endif; ?>
             </tr>
     <?php endforeach; ?>

--- a/modules/subscribe/api/Subscribe.php
+++ b/modules/subscribe/api/Subscribe.php
@@ -5,6 +5,7 @@ use Yii;
 use yii\easyii\modules\subscribe\models\Subscriber;
 
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\bootstrap\ActiveForm;
 
 class Subscribe extends \yii\easyii\components\API
@@ -23,7 +24,7 @@ class Subscribe extends \yii\easyii\components\API
         ob_start();
         $form = ActiveForm::begin([
             'enableAjaxValidation' => true,
-            'action' => '/admin/subscribe/send',
+            'action' => Url::to(['/admin/subscribe/send']),
             'layout' => 'inline'
         ]);
 

--- a/modules/subscribe/controllers/AController.php
+++ b/modules/subscribe/controllers/AController.php
@@ -3,10 +3,11 @@ namespace yii\easyii\modules\subscribe\controllers;
 
 use Yii;
 use yii\data\ActiveDataProvider;
-use yii\easyii\models\Setting;
+use yii\helpers\Url;
 use yii\widgets\ActiveForm;
 
 use yii\easyii\components\Controller;
+use yii\easyii\models\Setting;
 use yii\easyii\modules\subscribe\models\Subscriber;
 use yii\easyii\modules\subscribe\models\History;
 
@@ -40,7 +41,7 @@ class AController extends Controller
 
         if($model === null){
             $this->flash('error', Yii::t('easyii', 'Not found'));
-            return $this->redirect('/admin/subscribe/history');
+            return $this->redirect(['/admin/subscribe/history']);
         }
 
         return $this->render('view', [
@@ -61,7 +62,7 @@ class AController extends Controller
             {
                 if($model->validate() && $this->send($model)){
                     $this->flash('success', Yii::t('easyii/subscribe', 'Subscribe successfully created and sent'));
-                    return $this->redirect('/admin/subscribe/a/history');
+                    return $this->redirect(['/admin/subscribe/a/history']);
                 }
                 else{
                     $this->flash('error', Yii::t('easyii', 'Create error. {0}', $model->formatErrors()));
@@ -93,7 +94,7 @@ class AController extends Controller
                 "--------------------------------------------------------------------------------";
 
         foreach(Subscriber::find()->all() as $subscriber){
-            $unsubscribeLink = '<br><a href="http://'.Yii::$app->request->serverName.'/admin/subscribe/send/unsubscribe?email='.$subscriber->email.'" target="_blank">'.Yii::t('easyii/unsubscribe', 'Unsubscribe').'</a>';
+            $unsubscribeLink = '<br><a href="' . Url::to(['/admin/subscribe/send/unsubscribe', 'email' => $subscriber->email], true) . '" target="_blank">'.Yii::t('easyii/unsubscribe', 'Unsubscribe').'</a>';
 
             if(Yii::$app->mailer->compose()
                 ->setFrom(Setting::get('robot_email'))

--- a/modules/subscribe/views/a/_menu.php
+++ b/modules/subscribe/views/a/_menu.php
@@ -1,7 +1,9 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 
-$historyUrl = '/admin/subscribe/a/history';
+$historyUrl = Url::to(['/admin/subscribe/a/history']);
 if($action === 'view'){
     $returnUrl = $this->context->getReturnUrl();
     if(strpos($returnUrl, 'history') !== false){
@@ -11,10 +13,10 @@ if($action === 'view'){
 ?>
 <ul class="nav nav-pills">
     <li <?= ($action === 'index') ? 'class="active"' : '' ?>>
-        <a href="/admin/subscribe"><?= Yii::t('easyii/subscribe', 'Subscribers') ?></a>
+        <a href="<?= Url::to(['/admin/subscribe']) ?>"><?= Yii::t('easyii/subscribe', 'Subscribers') ?></a>
     </li>
     <li <?= ($action === 'create') ? 'class="active"' : '' ?>>
-        <a href="/admin/subscribe/a/create">
+        <a href="<?= Url::to(['/admin/subscribe/a/create']) ?>">
         <?= Yii::t('easyii/subscribe', 'Create subscribe') ?>
         </a>
     </li>

--- a/modules/subscribe/views/a/history.php
+++ b/modules/subscribe/views/a/history.php
@@ -1,4 +1,6 @@
 <?php
+use yii\helpers\Url;
+
 $this->title = Yii::t('easyii/subscribe', 'History');
 ?>
 
@@ -22,7 +24,7 @@ $this->title = Yii::t('easyii/subscribe', 'History');
                 <?php if(IS_ROOT) : ?>
                     <td><?= $item->primaryKey ?></td>
                 <?php endif; ?>
-                <td><a href="/admin/subscribe/a/view/<?= $item->primaryKey ?>"><?= $item->subject ?></a></td>
+                <td><a href="<?= Url::to(['/admin/subscribe/a/view', 'id' => $item->primaryKey]) ?>"><?= $item->subject ?></a></td>
                 <td><?= Yii::$app->formatter->asDatetime($item->time, 'short') ?></td>
                 <td><?= $item->sent ?></td>
             </tr>

--- a/modules/subscribe/views/a/index.php
+++ b/modules/subscribe/views/a/index.php
@@ -1,4 +1,6 @@
 <?php
+use yii\helpers\Url;
+
 $this->title = Yii::t('easyii/subscribe', 'Subscribe');
 ?>
 
@@ -26,7 +28,7 @@ $this->title = Yii::t('easyii/subscribe', 'Subscribe');
                 <td><?= $item->email ?></td>
                 <td><a href="//freegeoip.net/?q=<?= $item->ip ?>" target="_blank"><?= $item->ip ?></a></td>
                 <td><?= Yii::$app->formatter->asDatetime($item->time, 'short') ?></td>
-                <td class="control"><a href="/admin/subscribe/a/delete/<?= $item->primaryKey ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>
+                <td class="control"><a href="<?= Url::to(['/admin/subscribe/a/delete', 'id' => $item->primaryKey]) ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>
             </tr>
     <?php endforeach; ?>
         </tbody>

--- a/modules/text/api/Text.php
+++ b/modules/text/api/Text.php
@@ -3,6 +3,7 @@ namespace yii\easyii\modules\text\api;
 
 use Yii;
 use yii\easyii\helpers\Data;
+use yii\easyii\helpers\Url;
 use yii\easyii\modules\text\models\Text as TextModel;
 
 class Text extends \yii\easyii\components\API
@@ -57,7 +58,7 @@ class Text extends \yii\easyii\components\API
             return '';
         }
         elseif(preg_match(TextModel::$slugPattern, $id_slug)){
-            return '<a href="/admin/text/a/create/?slug='.$id_slug.'" target="_blank">'.Yii::t('easyii/text/api', 'Create text').'</a>';
+            return '<a href="' . Url::to(['/admin/text/a/create', 'slug' => $id_slug]) . '" target="_blank">'.Yii::t('easyii/text/api', 'Create text').'</a>';
         }
         else{
             return $this->errorText('WRONG TEXT IDENTIFIER');

--- a/modules/text/controllers/AController.php
+++ b/modules/text/controllers/AController.php
@@ -34,7 +34,7 @@ class AController extends Controller
             else{
                 if($model->save()){
                     $this->flash('success', Yii::t('easyii/text', 'Text created'));
-                    return $this->redirect('/admin/text');
+                    return $this->redirect(['/admin/text']);
                 }
                 else{
                     $this->flash('error', Yii::t('easyii', 'Create error. {0}', $model->formatErrors()));
@@ -58,7 +58,7 @@ class AController extends Controller
 
         if($model === null){
             $this->flash('error', Yii::t('easyii', 'Not found'));
-            return $this->redirect('/admin/text');
+            return $this->redirect(['/admin/text']);
         }
 
         if ($model->load(Yii::$app->request->post())) {

--- a/modules/text/views/a/_menu.php
+++ b/modules/text/views/a/_menu.php
@@ -1,23 +1,25 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 <?php if(IS_ROOT) : ?>
     <ul class="nav nav-pills">
         <li <?= ($action === 'index') ? 'class="active"' : '' ?>>
-            <a href="<?= $this->context->getReturnUrl('/admin/text') ?>">
+            <a href="<?= $this->context->getReturnUrl(['/admin/text']) ?>">
                 <?php if($action === 'edit') : ?>
                     <i class="glyphicon glyphicon-chevron-left font-12"></i>
                 <?php endif; ?>
                 <?= Yii::t('easyii', 'List') ?>
             </a>
         </li>
-        <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="/admin/text/a/create"><?= Yii::t('easyii', 'Create') ?></a></li>
+        <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/text/a/create']) ?>"><?= Yii::t('easyii', 'Create') ?></a></li>
     </ul>
     <br/>
 <?php elseif($action === 'edit') : ?>
     <ul class="nav nav-pills">
         <li>
-            <a href="<?= $this->context->getReturnUrl('/admin/text')?>">
+            <a href="<?= $this->context->getReturnUrl(['/admin/text'])?>">
                 <i class="glyphicon glyphicon-chevron-left font-12"></i>
                 <?= Yii::t('easyii/text', 'Texts') ?>
             </a>

--- a/modules/text/views/a/index.php
+++ b/modules/text/views/a/index.php
@@ -1,4 +1,6 @@
 <?php
+use yii\helpers\Url;
+
 $this->title = Yii::t('easyii/text', 'Texts');
 ?>
 
@@ -24,10 +26,10 @@ $this->title = Yii::t('easyii/text', 'Texts');
                 <?php if(IS_ROOT) : ?>
                 <td><?= $item->primaryKey ?></td>
                 <?php endif; ?>
-                <td><a href="/admin/text/a/edit/<?= $item->primaryKey ?>"><?= $item->text ?></a></td>
+                <td><a href="<?= Url::to(['/admin/text/a/edit', 'id' => $item->primaryKey]) ?>"><?= $item->text ?></a></td>
                 <?php if(IS_ROOT) : ?>
                     <td><?= $item->slug ?></td>
-                    <td><a href="/admin/text/a/delete/<?= $item->primaryKey ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>
+                    <td><a href="<?= Url::to(['/admin/text/a/delete', 'id' => $item->primaryKey]) ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>
                 <?php endif; ?>
             </tr>
     <?php endforeach; ?>

--- a/views/admins/_menu.php
+++ b/views/admins/_menu.php
@@ -1,15 +1,17 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 <ul class="nav nav-pills">
     <li <?= ($action === 'index') ? 'class="active"' : '' ?>>
-        <a href="<?= $this->context->getReturnUrl('/admin/admins') ?>">
+        <a href="<?= $this->context->getReturnUrl(['/admin/admins']) ?>">
             <?php if($action === 'edit') : ?>
                 <i class="glyphicon glyphicon-chevron-left font-12"></i>
             <?php endif; ?>
             <?= Yii::t('easyii', 'List') ?>
         </a>
     </li>
-    <li <?= ($action==='create') ? 'class="active"' : '' ?>><a href="/admin/admins/create"><?= Yii::t('easyii', 'Create') ?></a></li>
+    <li <?= ($action==='create') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/admins/create']) ?>"><?= Yii::t('easyii', 'Create') ?></a></li>
 </ul>
 <br/>

--- a/views/admins/index.php
+++ b/views/admins/index.php
@@ -1,4 +1,6 @@
 <?php
+use yii\helpers\Url;
+
 $this->title = Yii::t('easyii', 'Admins');
 ?>
 
@@ -17,8 +19,8 @@ $this->title = Yii::t('easyii', 'Admins');
         <?php foreach($data->models as $admin) : ?>
             <tr>
                 <td><?= $admin->admin_id ?></td>
-                <td><a href="/admin/admins/edit/<?= $admin->admin_id ?>"><?= $admin->username ?></a></td>
-                <td><a href="/admin/admins/delete/<?= $admin->admin_id ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>
+                <td><a href="<?= Url::to(['/admin/admins/edit', 'id' => $admin->admin_id]) ?>"><?= $admin->username ?></a></td>
+                <td><a href="<?= Url::to(['/admin/admins/delete', 'id' => $admin->admin_id]) ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>
             </tr>
         <?php endforeach; ?>
         </tbody>

--- a/views/install/finish.php
+++ b/views/install/finish.php
@@ -1,4 +1,6 @@
 <?php
+use yii\helpers\Url;
+
 $asset = \yii\easyii\assets\EmptyAsset::register($this);;
 
 $this->title = Yii::t('easyii/install', 'Installation completed');
@@ -11,7 +13,7 @@ $this->title = Yii::t('easyii/install', 'Installation completed');
                     <?= Yii::t('easyii/install', 'Installation completed') ?>
                 </div>
                 <div class="panel-body text-center">
-                    <a href="/admin">Go to control panel</a>
+                    <a href="<?= Url::to(['/admin']) ?>">Go to control panel</a>
                 </div>
             </div>
             <div class="text-center">

--- a/views/layouts/frontend-toolbar.php
+++ b/views/layouts/frontend-toolbar.php
@@ -15,7 +15,7 @@ $this->registerCss('body {padding-'.$position.': 50px;}');
             <li><a href="<?= Url::to(['/admin']) ?>"><span class="glyphicon glyphicon-arrow-left"></span> <?= Yii::t('easyii', 'Control Panel') ?></a></li>
         </ul>
         <p class="navbar-text"><i class="glyphicon glyphicon-pencil"></i> <?= Yii::t('easyii', 'Live edit') ?></p>
-        <?= Html::checkbox('', LIVE_EDIT) ?>
+        <?= Html::checkbox('', LIVE_EDIT, ['data-link' => Url::to(['/admin/system/live-edit'])]) ?>
 
         <ul class="nav navbar-nav navbar-right">
             <li><a href="<?= Url::to(['/admin/sign/out']) ?>"><span class="glyphicon glyphicon-log-out"></span> <?= Yii::t('easyii', 'Logout') ?></a></li>

--- a/views/layouts/frontend-toolbar.php
+++ b/views/layouts/frontend-toolbar.php
@@ -1,5 +1,6 @@
 <?php
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\easyii\assets\FrontendAsset;
 use yii\easyii\models\Setting;
 
@@ -11,13 +12,13 @@ $this->registerCss('body {padding-'.$position.': 50px;}');
 <nav id="easyii-navbar" class="navbar navbar-inverse navbar-fixed-<?= $position ?>">
     <div class="container">
         <ul class="nav navbar-nav navbar-left">
-            <li><a href="/admin"><span class="glyphicon glyphicon-arrow-left"></span> <?= Yii::t('easyii', 'Control Panel') ?></a></li>
+            <li><a href="<?= Url::to(['/admin']) ?>"><span class="glyphicon glyphicon-arrow-left"></span> <?= Yii::t('easyii', 'Control Panel') ?></a></li>
         </ul>
         <p class="navbar-text"><i class="glyphicon glyphicon-pencil"></i> <?= Yii::t('easyii', 'Live edit') ?></p>
         <?= Html::checkbox('', LIVE_EDIT) ?>
 
         <ul class="nav navbar-nav navbar-right">
-            <li><a href="/admin/sign/out"><span class="glyphicon glyphicon-log-out"></span> <?= Yii::t('easyii', 'Logout') ?></a></li>
+            <li><a href="<?= Url::to(['/admin/sign/out']) ?>"><span class="glyphicon glyphicon-log-out"></span> <?= Yii::t('easyii', 'Logout') ?></a></li>
         </ul>
     </div>
 </nav>

--- a/views/layouts/main.php
+++ b/views/layouts/main.php
@@ -28,7 +28,7 @@ $moduleName = $this->context->module->id;
                     EasyiiCMS
                 </div>
                 <div class="nav">
-                    <a href="/" class="pull-left"><i class="glyphicon glyphicon-home"></i> <?= Yii::t('easyii', 'Open site') ?></a>
+                    <a href="<?= Url::to(['/']) ?>" class="pull-left"><i class="glyphicon glyphicon-home"></i> <?= Yii::t('easyii', 'Open site') ?></a>
                     <a href="<?= Url::to(['/admin/sign/out']) ?>" class="pull-right"><i class="glyphicon glyphicon-log-out"></i> <?= Yii::t('easyii', 'Logout') ?></a>
                 </div>
             </div>

--- a/views/layouts/main.php
+++ b/views/layouts/main.php
@@ -1,5 +1,6 @@
 <?php
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\easyii\assets\AdminAsset;
 
 $asset = AdminAsset::register($this);
@@ -28,13 +29,13 @@ $moduleName = $this->context->module->id;
                 </div>
                 <div class="nav">
                     <a href="/" class="pull-left"><i class="glyphicon glyphicon-home"></i> <?= Yii::t('easyii', 'Open site') ?></a>
-                    <a href="/admin/sign/out" class="pull-right"><i class="glyphicon glyphicon-log-out"></i> <?= Yii::t('easyii', 'Logout') ?></a>
+                    <a href="<?= Url::to(['/admin/sign/out']) ?>" class="pull-right"><i class="glyphicon glyphicon-log-out"></i> <?= Yii::t('easyii', 'Logout') ?></a>
                 </div>
             </div>
             <div class="main">
                 <div class="box sidebar">
                     <?php foreach(Yii::$app->getModule('admin')->activeModules as $module) : ?>
-                        <a href="/admin/<?= $module->name ?>" class="menu-item <?= ($moduleName == $module->name ? 'active' : '') ?>">
+                        <a href="<?= Url::to(["/admin/$module->name"]) ?>" class="menu-item <?= ($moduleName == $module->name ? 'active' : '') ?>">
                             <?php if($module->icon != '') : ?>
                                 <i class="glyphicon glyphicon-<?= $module->icon ?>"></i>
                             <?php endif; ?>
@@ -44,24 +45,24 @@ $moduleName = $this->context->module->id;
                             <?php endif; ?>
                         </a>
                     <?php endforeach; ?>
-                    <a href="/admin/settings" class="menu-item <?= ($moduleName == 'admin' && $this->context->id == 'settings') ? 'active' :'' ?>">
+                    <a href="<?= Url::to(['/admin/settings']) ?>" class="menu-item <?= ($moduleName == 'admin' && $this->context->id == 'settings') ? 'active' :'' ?>">
                         <i class="glyphicon glyphicon-cog"></i>
                         <?= Yii::t('easyii', 'Settings') ?>
                     </a>
                     <?php if(IS_ROOT) : ?>
-                        <a href="/admin/modules" class="menu-item <?= ($moduleName == 'admin' && $this->context->id == 'modules') ? 'active' :'' ?>">
+                        <a href="<?= Url::to(['/admin/modules']) ?>" class="menu-item <?= ($moduleName == 'admin' && $this->context->id == 'modules') ? 'active' :'' ?>">
                             <i class="glyphicon glyphicon-folder-close"></i>
                             <?= Yii::t('easyii', 'Modules') ?>
                         </a>
-                        <a href="/admin/admins" class="menu-item <?= ($moduleName == 'admin' && $this->context->id == 'admins') ? 'active' :'' ?>">
+                        <a href="<?= Url::to(['/admin/admins']) ?>" class="menu-item <?= ($moduleName == 'admin' && $this->context->id == 'admins') ? 'active' :'' ?>">
                             <i class="glyphicon glyphicon-user"></i>
                             <?= Yii::t('easyii', 'Admins') ?>
                         </a>
-                        <a href="/admin/system" class="menu-item <?= ($moduleName == 'admin' && $this->context->id == 'system') ? 'active' :'' ?>">
+                        <a href="<?= Url::to(['/admin/system']) ?>" class="menu-item <?= ($moduleName == 'admin' && $this->context->id == 'system') ? 'active' :'' ?>">
                             <i class="glyphicon glyphicon-hdd"></i>
                             <?= Yii::t('easyii', 'System') ?>
                         </a>
-                        <a href="/admin/logs" class="menu-item <?= ($moduleName == 'admin' && $this->context->id == 'logs') ? 'active' :'' ?>">
+                        <a href="<?= Url::to(['/admin/logs']) ?>" class="menu-item <?= ($moduleName == 'admin' && $this->context->id == 'logs') ? 'active' :'' ?>">
                             <i class="glyphicon glyphicon-align-justify"></i>
                             <?= Yii::t('easyii', 'Logs') ?>
                         </a>

--- a/views/logs/_menu.php
+++ b/views/logs/_menu.php
@@ -1,7 +1,9 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 <ul class="nav nav-pills">
-    <li <?= ($action==='index') ? 'class="active"' : '' ?>><a href="/admin/logs"><?= Yii::t('easyii', 'Sign in') ?></a></li>
+    <li <?= ($action==='index') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/logs']) ?>"><?= Yii::t('easyii', 'Sign in') ?></a></li>
 </ul>
 <br/>

--- a/views/modules/_menu.php
+++ b/views/modules/_menu.php
@@ -1,15 +1,17 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 <ul class="nav nav-pills">
     <li <?= ($action === 'index') ? 'class="active"' : '' ?>>
-        <a href="<?= $this->context->getReturnUrl('/admin/modules') ?>">
+        <a href="<?= $this->context->getReturnUrl(['/admin/modules']) ?>">
             <?php if($action === 'edit' || $action === 'settings') : ?>
                 <i class="glyphicon glyphicon-chevron-left font-12"></i>
             <?php endif; ?>
             <?= Yii::t('easyii', 'List') ?>
         </a>
     </li>
-    <li <?= ($action==='create') ? 'class="active"' : '' ?>><a href="/admin/modules/create"><?= Yii::t('easyii', 'Create') ?></a></li>
+    <li <?= ($action==='create') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/modules/create']) ?>"><?= Yii::t('easyii', 'Create') ?></a></li>
 </ul>
 <br/>

--- a/views/modules/_submenu.php
+++ b/views/modules/_submenu.php
@@ -1,9 +1,11 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 
 <ul class="nav nav-tabs">
-    <li <?= ($action === 'edit') ? 'class="active"' : '' ?>><a href="/admin/modules/edit/<?= $model->primaryKey ?>"> <?= Yii::t('easyii', 'Basic') ?></a></li>
-    <li <?= ($action === 'settings') ? 'class="active"' : '' ?>><a href="/admin/modules/settings/<?= $model->primaryKey ?>"><i class="glyphicon glyphicon-cog"></i> <?= Yii::t('easyii', 'Advanced') ?></a></li>
+    <li <?= ($action === 'edit') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/modules/edit/', 'id' => $model->primaryKey]) ?>"> <?= Yii::t('easyii', 'Basic') ?></a></li>
+    <li <?= ($action === 'settings') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/modules/settings/', 'id' => $model->primaryKey]) ?>"><i class="glyphicon glyphicon-cog"></i> <?= Yii::t('easyii', 'Advanced') ?></a></li>
 </ul>
 <br>

--- a/views/modules/index.php
+++ b/views/modules/index.php
@@ -1,6 +1,7 @@
 <?php
 use yii\easyii\models\Module;
 use yii\helpers\Html;
+use yii\helpers\Url;
 
 $this->title = Yii::t('easyii', 'Modules');
 ?>
@@ -23,7 +24,7 @@ $this->title = Yii::t('easyii', 'Modules');
         <?php foreach($data->models as $module) : ?>
             <tr>
                 <td><?= $module->primaryKey ?></td>
-                <td><a href="/admin/modules/edit/<?= $module->primaryKey ?>" title="<?= Yii::t('easyii', 'Edit') ?>"><?= $module->name ?></a></td>
+                <td><a href="<?= Url::to(['/admin/modules/edit/', 'id' => $module->primaryKey]) ?>" title="<?= Yii::t('easyii', 'Edit') ?>"><?= $module->name ?></a></td>
                 <td><?= $module->title ?></td>
                 <td>
                     <?php if($module->icon) : ?>
@@ -40,9 +41,9 @@ $this->title = Yii::t('easyii', 'Modules');
                 </td>
                 <td class="control">
                     <div class="btn-group btn-group-sm" role="group">
-                        <a href="/admin/modules/up/<?= $module->primaryKey ?>" class="btn btn-default" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
-                        <a href="/admin/modules/down/<?= $module->primaryKey ?>" class="btn btn-default" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
-                        <a href="/admin/modules/delete/<?= $module->primaryKey ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
+                        <a href="<?= Url::to(['/admin/modules/up/', 'id' => $module->primaryKey]) ?>" class="btn btn-default" title="<?= Yii::t('easyii', 'Move up') ?>"><span class="glyphicon glyphicon-arrow-up"></span></a>
+                        <a href="<?= Url::to(['/admin/modules/down/', 'id' => $module->primaryKey]) ?>" class="btn btn-default" title="<?= Yii::t('easyii', 'Move down') ?>"><span class="glyphicon glyphicon-arrow-down"></span></a>
+                        <a href="<?= Url::to(['/admin/modules/delete/', 'id' => $module->primaryKey]) ?>" class="btn btn-default confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"><span class="glyphicon glyphicon-remove"></span></a>
                     </div>
                 </td>
             </tr>

--- a/views/modules/index.php
+++ b/views/modules/index.php
@@ -35,7 +35,7 @@ $this->title = Yii::t('easyii', 'Modules');
                     <?= Html::checkbox('', $module->status == Module::STATUS_ON, [
                         'class' => 'switch',
                         'data-id' => $module->primaryKey,
-                        'data-link' => '/admin/modules/',
+                        'data-link' => Url::to(['/admin/modules/']) . '/',
                         'data-reload' => '1'
                     ]) ?>
                 </td>

--- a/views/modules/index.php
+++ b/views/modules/index.php
@@ -35,7 +35,7 @@ $this->title = Yii::t('easyii', 'Modules');
                     <?= Html::checkbox('', $module->status == Module::STATUS_ON, [
                         'class' => 'switch',
                         'data-id' => $module->primaryKey,
-                        'data-link' => Url::to(['/admin/modules/']) . '/',
+                        'data-link' => Url::to(['/admin/modules/']),
                         'data-reload' => '1'
                     ]) ?>
                 </td>

--- a/views/modules/settings.php
+++ b/views/modules/settings.php
@@ -1,5 +1,7 @@
 <?php
 use yii\helpers\Html;
+use yii\helpers\Url;
+
 $this->title = $model->title;
 ?>
 <?= $this->render('_menu') ?>
@@ -26,4 +28,4 @@ $this->title = $model->title;
 <?php else : ?>
     <?= $model->title ?> <?= Yii::t('easyii', 'module doesn`t have any settings.') ?>
 <?php endif; ?>
-<a href="/admin/modules/restoresettings/<?= $model->module_id ?>" class="pull-right text-warning"><i class="glyphicon glyphicon-flash"></i> <?= Yii::t('easyii', 'Restore default settings') ?></a>
+<a href="<?= Url::to(['/admin/modules/restoresettings', 'id' => $model->module_id]) ?>" class="pull-right text-warning"><i class="glyphicon glyphicon-flash"></i> <?= Yii::t('easyii', 'Restore default settings') ?></a>

--- a/views/settings/_menu.php
+++ b/views/settings/_menu.php
@@ -1,4 +1,6 @@
 <?php
+use yii\helpers\Url;
+
 $action = $this->context->action->id;
 ?>
 <?php if(IS_ROOT) : ?>
@@ -11,7 +13,7 @@ $action = $this->context->action->id;
                 <?= Yii::t('easyii', 'List') ?>
             </a>
         </li>
-        <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="/admin/settings/create"><?= Yii::t('easyii', 'Create') ?></a></li>
+        <li <?= ($action === 'create') ? 'class="active"' : '' ?>><a href="<?= Url::to(['/admin/settings/create']) ?>"><?= Yii::t('easyii', 'Create') ?></a></li>
     </ul>
     <br/>
 <?php elseif($action === 'edit') : ?>

--- a/views/settings/index.php
+++ b/views/settings/index.php
@@ -1,5 +1,6 @@
 <?php
 use yii\easyii\models\Setting;
+use yii\helpers\Url;
 
 $this->title = Yii::t('easyii', 'Settings');
 ?>
@@ -28,10 +29,10 @@ $this->title = Yii::t('easyii', 'Settings');
                     <td><?= $setting->primaryKey ?></td>
                     <td><?= $setting->name ?></td>
                 <?php endif; ?>
-                <td><a href="/admin/settings/edit/<?= $setting->primaryKey ?>" title="<?= Yii::t('easyii', 'Edit') ?>"><?= $setting->title ?></a></td>
+                <td><a href="<?= Url::to(['/admin/settings/edit', 'id' => $setting->primaryKey]) ?>" title="<?= Yii::t('easyii', 'Edit') ?>"><?= $setting->title ?></a></td>
                 <td style="overflow: hidden"><?= $setting->value ?></td>
                 <?php if(IS_ROOT) : ?>
-                    <td><a href="/admin/settings/delete/<?= $setting->primaryKey ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>
+                    <td><a href="<?= Url::to(['/admin/settings/delete', 'id' => $setting->primaryKey]) ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>
                 <?php endif; ?>
             </tr>
         <?php endforeach; ?>

--- a/views/system/index.php
+++ b/views/system/index.php
@@ -1,23 +1,24 @@
 <?php
 use yii\easyii\models\Setting;
+use yii\helpers\Url;
 
 $this->title = Yii::t('easyii', 'System');
 ?>
 
 <h4><?= Yii::t('easyii', 'Current version') ?>: <b><?= Setting::get('easyii_version') ?></b>
     <?php if(\yii\easyii\AdminModule::VERSION > floatval(Setting::get('easyii_version'))) : ?>
-        <a href="/admin/system/update" class="btn btn-success"><?= Yii::t('easyii', 'Update') ?></a>
+        <a href="<?= Url::to(['/admin/system/update']) ?>" class="btn btn-success"><?= Yii::t('easyii', 'Update') ?></a>
     <?php endif; ?>
 </h4>
 
 <br>
 
 <p>
-    <a href="/admin/system/flush-cache" class="btn btn-default"><i class="glyphicon glyphicon-flash"></i> <?= Yii::t('easyii', 'Flush cache') ?></a>
+    <a href="<?= Url::to(['/admin/system/flush-cache']) ?>" class="btn btn-default"><i class="glyphicon glyphicon-flash"></i> <?= Yii::t('easyii', 'Flush cache') ?></a>
 </p>
 
 <br>
 
 <p>
-    <a href="/admin/system/clear-assets" class="btn btn-default"><i class="glyphicon glyphicon-trash"></i> <?= Yii::t('easyii', 'Clear assets') ?></a>
+    <a href="<?= Url::to(['/admin/system/clear-assets']) ?>" class="btn btn-default"><i class="glyphicon glyphicon-trash"></i> <?= Yii::t('easyii', 'Clear assets') ?></a>
 </p>

--- a/views/system/update.php
+++ b/views/system/update.php
@@ -1,9 +1,11 @@
 <?php
+use yii\helpers\Url;
+
 $this->title = Yii::t('easyii', 'Update');
 ?>
 <ul class="nav nav-pills">
     <li>
-        <a href="/admin/system">
+        <a href="<?= Url::to(['/admin/system']) ?>">
             <i class="glyphicon glyphicon-chevron-left font-12"></i>
             <?= Yii::t('easyii', 'Back') ?>
         </a>

--- a/widgets/views/photos.php
+++ b/widgets/views/photos.php
@@ -1,6 +1,7 @@
 <?php
 use yii\easyii\widgets\Fancybox;
 use yii\helpers\Html;
+use yii\helpers\Url;
 use yii\easyii\assets\PhotosAsset;
 
 PhotosAsset::register($this);
@@ -9,27 +10,27 @@ Fancybox::widget(['selector' => '.plugin-box']);
 $model = get_class($this->context->model);
 $item_id = $this->context->model->primaryKey;
 
-$linkParams = http_build_query([
+$linkParams = [
     'model' => $model,
     'item_id' => $item_id,
     'maxWidth' => $this->context->maxWidth,
     'thumbWidth' => $this->context->thumbWidth,
     'thumbHeight' => $this->context->thumbHeight,
     'thumbCrop' => $this->context->thumbCrop,
-]);
+];
 
 $photoTemplate = '<tr data-id="{{photo_id}}">'.(IS_ROOT ? '<td>{{photo_id}}</td>' : '').'\
     <td><a href="{{photo_image}}" class="plugin-box" title="{{photo_description}}" rel="easyii-photos"><img class="photo-thumb" id="photo-{{photo_id}}" src="{{photo_thumb}}"></a></td>\
     <td>\
         <textarea class="form-control photo-description">{{photo_description}}</textarea>\
-        <a href="#" class="btn btn-sm btn-primary disabled save-photo-description">'. Yii::t('easyii', 'Save') .'</a>\
+        <a href="' . Url::to(['/admin/photos/description/{{photo_id}}']) . '" class="btn btn-sm btn-primary disabled save-photo-description">'. Yii::t('easyii', 'Save') .'</a>\
     </td>\
     <td class="control vtop">\
         <div class="btn-group btn-group-sm" role="group">\
-            <a href="/admin/photos/up/{{photo_id}}?'. $linkParams .'" class="btn btn-default move-up" title="'. Yii::t('easyii', 'Move up') .'"><span class="glyphicon glyphicon-arrow-up"></span></a>\
-            <a href="/admin/photos/down/{{photo_id}}?'. $linkParams .'" class="btn btn-default move-down" title="'. Yii::t('easyii', 'Move down') .'"><span class="glyphicon glyphicon-arrow-down"></span></a>\
-            <a href="/admin/photos/image/{{photo_id}}?'. $linkParams .'" class="btn btn-default change-image-button" title="'. Yii::t('easyii', 'Change image') .'"><span class="glyphicon glyphicon-floppy-disk"></span></a>\
-            <a href="/admin/photos/delete/{{photo_id}}" class="btn btn-default color-red delete-photo" title="'. Yii::t('easyii', 'Delete item') .'"><span class="glyphicon glyphicon-remove"></span></a>\
+            <a href="' . Url::to(['/admin/photos/up/{{photo_id}}'] + $linkParams) . '" class="btn btn-default move-up" title="'. Yii::t('easyii', 'Move up') .'"><span class="glyphicon glyphicon-arrow-up"></span></a>\
+            <a href="' . Url::to(['/admin/photos/down/{{photo_id}}'] + $linkParams) . '" class="btn btn-default move-down" title="'. Yii::t('easyii', 'Move down') .'"><span class="glyphicon glyphicon-arrow-down"></span></a>\
+            <a href="' . Url::to(['/admin/photos/image/{{photo_id}}'] + $linkParams) . '" class="btn btn-default change-image-button" title="'. Yii::t('easyii', 'Change image') .'"><span class="glyphicon glyphicon-floppy-disk"></span></a>\
+            <a href="' . Url::to(['/admin/photos/delete/{{photo_id}}']) . '" class="btn btn-default color-red delete-photo" title="'. Yii::t('easyii', 'Delete item') .'"><span class="glyphicon glyphicon-remove"></span></a>\
             <input type="file" name="Photo[image]" class="change-image-input hidden">\
         </div>\
     </td>\
@@ -65,7 +66,7 @@ $photoTemplate = str_replace('>\\', '>', $photoTemplate);
 </table>
 <p class="empty" style="display: <?= count($photos) ? 'none' : 'block' ?>;"><?= Yii::t('easyii', 'No photos uploaded yet') ?>.</p>
 
-<?= Html::beginForm('/admin/photos/upload?'.$linkParams, 'post', ['enctype' => 'multipart/form-data']) ?>
+<?= Html::beginForm(Url::to(['/admin/photos/upload'] + $linkParams), 'post', ['enctype' => 'multipart/form-data']) ?>
 <?= Html::fileInput('', null, [
     'id' => 'photo-file',
     'class' => 'hidden',


### PR DESCRIPTION
As discussed in Issue #19 

Extensive pull request, that changes all instances of direct static links and redirects to use yii's Url Helper class. Most of changes are trivial, but there are some modification to helpers and controllers that deal with file and image upload, particularly where url generation is concerned. 

I tried to keep changes as small as possible, it's not unlikely that some areas can rewritten more efficiently, but the point of this fix is to make Easyii work from other than root directory, nothing more.

I've tested most of the functionality of all modules as well as the main system. All seems to work fine, but taking into account the extent of this fix, there might be some minor bugs. It shouldn't be anything critical though. 

CMS should be tested while installed in other than the root directory to discover any possible problems.