### PR TITLE
Fix Url helper usage

### DIFF
--- a/modules/text/api/Text.php
+++ b/modules/text/api/Text.php
@@ -3,7 +3,7 @@ namespace yii\easyii\modules\text\api;
 
 use Yii;
 use yii\easyii\helpers\Data;
-use yii\easyii\helpers\Url;
+use yii\helpers\Url;
 use yii\easyii\modules\text\models\Text as TextModel;
 
 class Text extends \yii\easyii\components\API


### PR DESCRIPTION
There is no easyii URL helper class, so I changed it to the default Yii2 one. Works as expected now, was throwing an error before.