### PR TITLE
Multilanguage support

### DIFF
--- a/components/LangUrlManager.php
+++ b/components/LangUrlManager.php
@@ -1,0 +1,51 @@
+<?php
+namespace yii\easyii\components;
+
+use yii\web\UrlManager;
+
+class LangUrlManager extends UrlManager
+{
+    private $currentLanguage;
+
+    public $languages = [ 'ru' => 'ru-RU', 'en' => 'en-US'];
+
+    /**
+     * Parses the user request.
+     *
+     */
+    public function parseRequest($request)
+    {
+        $session = \Yii::$app->session;
+        if ($this->enablePrettyUrl) {
+            $urlInfo = $request->getUrl();
+            $urlComponents = explode('/',$urlInfo);
+            if ( isset($urlComponents[1]) && in_array($urlComponents[1],array_keys($this->languages))) {
+                $this->currentLanguage = $urlComponents[1];
+                $modifyRequest = new \yii\web\Request();
+                $modifyRequest->setUrl( substr($urlInfo,strlen($urlComponents[1])+1) );
+            }
+        }
+        if (!$this->currentLanguage) {
+            $session_lang = $session->get('language');
+            $this->currLang = isset($session_lang) ? $session_lang : substr(\Yii::$app->language,0,2) ;
+        }
+        if ( $session->get('language') != $this->currentLanguage )
+            $session->set('language',$this->currentLanguage);
+        \Yii::$app->language = $this->languages[$this->currentLanguage];
+        return parent::parseRequest($modifyRequest ? $modifyRequest : $request);
+    }
+    /**
+     * Creates a URL using the given route and query parameters.
+     * Add lang param before route
+     */
+    public function createUrl($params)
+    {
+        $params = array_merge(['language'=> $this->currentLanguage],(array)$params);
+        $lang = $params['language'];
+        if ($this->enablePrettyUrl)
+            unset($params['language']);
+        $url = parent::createUrl($params);
+        return $this->enablePrettyUrl ? '/'.$lang . ($url === '/' ? '' : $url ) : $url;
+    }
+
+}

--- a/components/LangUrlManager.php
+++ b/components/LangUrlManager.php
@@ -26,8 +26,8 @@ class LangUrlManager extends UrlManager
             }
         }
         if (!$this->currentLanguage) {
-            $session_lang = $session->get('language');
-            $this->currLang = isset($session_lang) ? $session_lang : substr(\Yii::$app->language,0,2) ;
+            $sessionLanguage = $session->get('language');
+            $this->currentLanguage = isset($sessionLanguage) ? $sessionLanguage : substr(\Yii::$app->language,0,2) ;
         }
         if ( $session->get('language') != $this->currentLanguage )
             $session->set('language',$this->currentLanguage);

--- a/components/LangUrlManager.php
+++ b/components/LangUrlManager.php
@@ -7,7 +7,7 @@ class LangUrlManager extends UrlManager
 {
     private $currentLanguage;
 
-    public $languages = [ 'ru' => 'ru-RU', 'en' => 'en-US'];
+    public $languages = ['ru' => 'ru-RU', 'en' => 'en-US'];
 
     /**
      * Parses the user request.
@@ -29,10 +29,11 @@ class LangUrlManager extends UrlManager
             $sessionLanguage = $session->get('language');
             $this->currentLanguage = isset($sessionLanguage) ? $sessionLanguage : substr(\Yii::$app->language,0,2) ;
         }
-        if ( $session->get('language') != $this->currentLanguage )
+        if ( $session->get('language') != $this->currentLanguage ) {
             $session->set('language',$this->currentLanguage);
+        }
         \Yii::$app->language = $this->languages[$this->currentLanguage];
-        return parent::parseRequest($modifyRequest ? $modifyRequest : $request);
+        return parent::parseRequest(isset($modifyRequest) ? $modifyRequest : $request);
     }
     /**
      * Creates a URL using the given route and query parameters.


### PR DESCRIPTION
Just add settings into web.php

``` php
        'urlManager' => [
            'class'=>'yii\easyii\components\LangUrlManager',
            'languages' => [ 'de' => 'de-DE', 'ru' => 'ru-RU', 'en' => 'en-US'],
            ...
        ]
```

Language remembered in user session, always showing in url ( good for SEO ) and easy switching in Layouts with sample code:

``` php
<?
                        foreach (\Yii::$app->urlManager->languages as $language => $locale ) {
                            $_langs .= (isset($_langs) ? ' | ' : '') . Html::a(mb_strtoupper($language), Url::current(['language' => $language]));
                                };
                        echo $_langs;
?>
```
