### PR TITLE
Fixed the lack of a necessary dependency

### DIFF
--- a/assets/DateTimePickerAsset.php
+++ b/assets/DateTimePickerAsset.php
@@ -14,13 +14,11 @@ class DateTimePickerAsset extends \yii\web\AssetBundle
     {
         if (YII_DEBUG) {
             $this->js[] = 'moment/min/moment-with-locales.js';
-            $this->js[] = 'bootstrap-datepicker/dist/js/bootstrap-datepicker.js';
             $this->js[] = 'eonasdan-bootstrap-datetimepicker/src/js/bootstrap-datetimepicker.js';
             $this->css[] = 'eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.css';
         } else {
             $this->js[] = 'moment/min/moment-with-locales.min.js';
-            $this->js[] = 'bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js';
-            $this->js[] = 'eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.jsredactor.min.js';
+            $this->js[] = 'eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js';
             $this->css[] = 'eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css';
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "creocoder/yii2-nested-sets": "0.9.*",
         "bower-asset/fancybox": "*",
         "bower-asset/jquery.switcher": "*",
+        "bower-asset/bootstrap-datepicker": "*",
         "bower-asset/eonasdan-bootstrap-datetimepicker": "^4.7@dev",
         "2amigos/yii2-selectize-widget": "~1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "creocoder/yii2-nested-sets": "0.9.*",
         "bower-asset/fancybox": "*",
         "bower-asset/jquery.switcher": "*",
-        "bower-asset/bootstrap-datepicker": "*",
         "bower-asset/eonasdan-bootstrap-datetimepicker": "^4.7@dev",
         "2amigos/yii2-selectize-widget": "~1.0"
     },


### PR DESCRIPTION
Fixed this js error: 

Failed to load resource:  .../assets/a56857d2/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js 

on the news/articles/etc edit page of the admin panel.

