### PR TITLE
Fix Bug of Category for php and style of admin to show icons

### DIFF
--- a/media/css/admin.css
+++ b/media/css/admin.css
@@ -103,6 +103,7 @@ html{
 }
 #admin-body .main a, #admin-body .main .btn, #admin-body .main .form-control, .input-group-addon{
     border-radius: 0 !important;
+    text-align: left;
 }
 
 #admin-body .table {
@@ -212,4 +213,7 @@ h4 b{
 .dashed-link:hover, .dashed-link:focus{
     text-decoration: none;
     color: #333;
+}
+.glyphicon-menu-hamburger:before {
+  content: "\e055";
 }

--- a/views/category/index.php
+++ b/views/category/index.php
@@ -29,8 +29,8 @@ $baseUrl = '/admin/'.$this->context->moduleName;
                     </td>
                     <td width="120" class="text-right">
                         <div class="dropdown actions">
-                            <i id="dropdownMenu'.$node->category_id.'" data-toggle="dropdown" aria-expanded="true" title="'.Yii::t('easyii', 'Actions').'" class="glyphicon glyphicon-menu-hamburger"></i>
-                            <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenu'.$node->category_id.'">
+                            <i id="dropdownMenu<?=$cat->category_id;?>" data-toggle="dropdown" aria-expanded="true" title="<?= Yii::t('easyii', 'Actions'); ?>" class="glyphicon glyphicon-menu-hamburger"></i>
+                            <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenu<?=$cat->category_id;?>">
                                 <li><a href="<?= Url::to([$baseUrl.'/a/edit', 'id' => $cat->category_id]) ?>"><i class="glyphicon glyphicon-pencil font-12"></i> <?= Yii::t('easyii', 'Edit') ?></a></li>
                                 <li><a href="<?= Url::to([$baseUrl.'/a/create', 'parent' => $cat->category_id]) ?>"><i class="glyphicon glyphicon-plus font-12"></i> <?= Yii::t('easyii', 'Add subcategory') ?></a></li>
                                 <li role="presentation" class="divider"></li>


### PR DESCRIPTION
After installation of easyii-shop with composer, in articles I can't see Icons of actions to create subcategory and others.Then I add some code to admin.css to show this Icon.
AND
In category of showing this button there is some bug that codes don't have <?=
