### PR TITLE
Update Catalog.php

### DIFF
--- a/modules/catalog/api/Catalog.php
+++ b/modules/catalog/api/Catalog.php
@@ -171,7 +171,7 @@ class Catalog extends \yii\easyii\components\API
                     }
                 }
                 if($filtersApplied) {
-                    $query->join('LEFT JOIN', ['f' => $subQuery], 'f.item_id = '.Item::tableName().'.item_id');
+                    $query->join('LEFT JOIN', ['f' => $subQuery], 'f.item_id = '.Item::tableName().'.id');
                     $query->andFilterWhere(['f.filter_matched' => $filtersApplied]);
                 }
             }


### PR DESCRIPTION
Опечатка в названии колонки (у таблицы easyii_catalog_items нет колонки item_id) вызывает ошибку при попытке применить фильтр через параметр 'filters' (напр., Catalog::items(['filters' => ['size' => '2']])
