### PR TITLE
Add function strip_tags in view file index.php module Text

### DIFF
--- a/modules/text/views/a/index.php
+++ b/modules/text/views/a/index.php
@@ -28,7 +28,7 @@ $module = $this->context->module->id;
                 <?php if(IS_ROOT) : ?>
                 <td><?= $item->primaryKey ?></td>
                 <?php endif; ?>
-                <td><a href="<?= Url::to(['/admin/'.$module.'/a/edit', 'id' => $item->primaryKey]) ?>"><?= $item->text ?></a></td>
+                <td><a href="<?= Url::to(['/admin/'.$module.'/a/edit', 'id' => $item->primaryKey]) ?>"><?= strip_tags($item->text) ?></a></td>
                 <?php if(IS_ROOT) : ?>
                     <td><?= $item->slug ?></td>
                     <td><a href="<?= Url::to(['/admin/'.$module.'/a/delete', 'id' => $item->primaryKey]) ?>" class="glyphicon glyphicon-remove confirm-delete" title="<?= Yii::t('easyii', 'Delete item') ?>"></a></td>


### PR DESCRIPTION
Заказчики используют данный модуль для размещения счетчиков на сайте, при таком кейсе невозможно отредактировать исходник, получается тег `<a>` отображается в теге `<a>` и ссылка подменяется.
