### PR TITLE
Update Carousel.php

### DIFF
--- a/modules/carousel/api/Carousel.php
+++ b/modules/carousel/api/Carousel.php
@@ -61,11 +61,14 @@ class Carousel extends API
             $items[] = $temp;
         }
 
-        $widget = \yii\bootstrap\Carousel::widget([
+        $widgetItems = [
             'options' => ['class' => 'slide'],
             'clientOptions' => $this->clientOptions,
             'items' => $items
-        ]);
+        ];
+            if(isset($this->clientOptions['controls']))
+                $widgetItems['controls'] = $this->clientOptions['controls'];
+        $widget = \yii\bootstrap\Carousel::widget($widgetItems);
 
         return LIVE_EDIT ? API::liveEdit($widget, Url::to(['/admin/carousel']), 'div') : $widget;
     }


### PR DESCRIPTION
controls option is not sent through to yii bootstrap carousel, this modification passes them through
use sample:
` <?php echo Carousel::widget(1920, 720,['interval' => 6000, 'controls' => ['<i class="mol_carousel__arrowleft fa fa fa-arrow-left"></i>','<i class="mol_carousel__arrowright fa fa fa-arrow-right"></i>']]);?>`